### PR TITLE
feat: 회원 가입, 로그인, 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/member/controller/AuthRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/controller/AuthRestController.java
@@ -1,0 +1,49 @@
+package com.fc.shimpyo_be.domain.member.controller;
+
+import com.fc.shimpyo_be.domain.member.dto.request.RefreshRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignInRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignUpRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.SignInResponseDto;
+import com.fc.shimpyo_be.domain.member.service.AuthService;
+import com.fc.shimpyo_be.global.common.ResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthRestController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ResponseDto<MemberResponseDto>> signUp(
+        @Valid @RequestBody SignUpRequestDto signUpRequestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ResponseDto.res(HttpStatus.CREATED, authService.signUp(signUpRequestDto),
+                "성공적으로 회원가입 했습니다."));
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<ResponseDto<SignInResponseDto>> signIn(
+        @Valid @RequestBody SignInRequestDto signInRequestDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDto.res(HttpStatus.OK, authService.signIn(signInRequestDto),
+                "성공적으로 로그인 했습니다."));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ResponseDto<SignInResponseDto>> refresh(
+        @Valid @RequestBody RefreshRequestDto refreshRequestDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDto.res(HttpStatus.OK, authService.refresh(refreshRequestDto),
+                "성공적으로 토큰을 재발급 했습니다."));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/controller/AuthRestControllerAdvice.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/controller/AuthRestControllerAdvice.java
@@ -1,0 +1,59 @@
+package com.fc.shimpyo_be.domain.member.controller;
+
+import com.fc.shimpyo_be.domain.member.exception.AlreadyExistsMemberException;
+import com.fc.shimpyo_be.domain.member.exception.InvalidRefreshTokenException;
+import com.fc.shimpyo_be.domain.member.exception.LoggedOutException;
+import com.fc.shimpyo_be.domain.member.exception.MemberNotFoundException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedMemberException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
+import com.fc.shimpyo_be.global.common.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class AuthRestControllerAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> MemberNotFoundException(
+        MemberNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ResponseDto.res(HttpStatus.NOT_FOUND, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> alreadySignUpException(
+        AlreadyExistsMemberException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> InvalidRefreshTokenException(
+        InvalidRefreshTokenException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> loggedOutException(
+        LoggedOutException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> unmatchedMemberException(
+        UnmatchedMemberException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> unmatchedPasswordException(
+        UnmatchedPasswordException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/RefreshRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/RefreshRequestDto.java
@@ -1,0 +1,22 @@
+package com.fc.shimpyo_be.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshRequestDto {
+
+    @NotBlank(message = "Access Token 을 입력하세요.")
+    private String accessToken;
+    @NotBlank(message = "Refresh Token 을 입력하세요.")
+    private String refreshToken;
+
+    @Builder
+    public RefreshRequestDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/SignInRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/SignInRequestDto.java
@@ -1,0 +1,32 @@
+package com.fc.shimpyo_be.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@Getter
+@NoArgsConstructor
+public class SignInRequestDto {
+
+    @NotBlank(message = "이메일을 입력하세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식에 맞게 입력해주세요.")
+    private String email;
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 이상, 최대 30자 이내로 입력하세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,30}$", message = "비밀번호 확인은 문자, 숫자, 특수문자를 포함하여 입력해주세요.")
+    private String password;
+
+    @Builder
+    public SignInRequestDto(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public UsernamePasswordAuthenticationToken toAuthentication(){
+        return new UsernamePasswordAuthenticationToken(this.email, this.password);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/SignInRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/SignInRequestDto.java
@@ -16,8 +16,6 @@ public class SignInRequestDto {
     @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식에 맞게 입력해주세요.")
     private String email;
     @NotBlank(message = "비밀번호를 입력하세요.")
-    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 이상, 최대 30자 이내로 입력하세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,30}$", message = "비밀번호 확인은 문자, 숫자, 특수문자를 포함하여 입력해주세요.")
     private String password;
 
     @Builder

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/SignUpRequestDto.java
@@ -1,0 +1,49 @@
+package com.fc.shimpyo_be.domain.member.dto.request;
+
+import com.fc.shimpyo_be.domain.member.entity.Authority;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Getter
+@NoArgsConstructor
+public class SignUpRequestDto {
+
+    @NotBlank(message = "이메일을 입력하세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식에 맞게 입력해주세요.")
+    private String email;
+    @NotBlank(message = "이름을 입력하세요.")
+    @Size(min = 2, max = 30, message = "이름은 최소 2자 이상 최대 30자 이내로 입력하세요.")
+    private String name;
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 8, max = 30, message = "비밀번호는 최소 9자 이상, 최대 30자 이내로 입력하세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,30}$", message = "비밀번호는 문자, 숫자, 특수문자를 포함하여 입력해주세요.")
+    private String password;
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 8, max = 30, message = "비밀번호 확인은 최소 9자 이상, 최대 30자 이내로 입력하세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,30}$", message = "비밀번호 확인은 문자, 숫자, 특수문자를 포함하여 입력해주세요.")
+    private String passwordConfirm;
+
+    @Builder
+    public SignUpRequestDto(String email, String name, String password, String passwordConfirm) {
+        this.email = email;
+        this.name = name;
+        this.password = password;
+        this.passwordConfirm = passwordConfirm;
+    }
+
+    public Member toMember(PasswordEncoder passwordEncoder) {
+        return Member.builder()
+            .email(this.email)
+            .name(this.name)
+            .password(passwordEncoder.encode(this.password))
+            .photoUrl("")
+            .authority(Authority.ROLE_USER)
+            .build();
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/SignUpRequestDto.java
@@ -21,12 +21,8 @@ public class SignUpRequestDto {
     @Size(min = 2, max = 30, message = "이름은 최소 2자 이상 최대 30자 이내로 입력하세요.")
     private String name;
     @NotBlank(message = "비밀번호를 입력하세요.")
-    @Size(min = 8, max = 30, message = "비밀번호는 최소 9자 이상, 최대 30자 이내로 입력하세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,30}$", message = "비밀번호는 문자, 숫자, 특수문자를 포함하여 입력해주세요.")
     private String password;
-    @NotBlank(message = "비밀번호를 입력하세요.")
-    @Size(min = 8, max = 30, message = "비밀번호 확인은 최소 9자 이상, 최대 30자 이내로 입력하세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,30}$", message = "비밀번호 확인은 문자, 숫자, 특수문자를 포함하여 입력해주세요.")
+    @NotBlank(message = "비밀번호 확인을 입력하세요.")
     private String passwordConfirm;
 
     @Builder

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/response/MemberResponseDto.java
@@ -1,0 +1,33 @@
+package com.fc.shimpyo_be.domain.member.dto.response;
+
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberResponseDto {
+
+    private Long memberId;
+    private String email;
+    private String name;
+    private String photoUrl;
+
+    @Builder
+    public MemberResponseDto(Long memberId, String email, String name, String photoUrl) {
+        this.memberId = memberId;
+        this.email = email;
+        this.name = name;
+        this.photoUrl = photoUrl;
+    }
+
+    public static MemberResponseDto of(Member member) {
+        return MemberResponseDto.builder()
+            .memberId(member.getId())
+            .email(member.getEmail())
+            .name(member.getName())
+            .photoUrl(member.getPhotoUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/response/SignInResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/response/SignInResponseDto.java
@@ -1,0 +1,26 @@
+package com.fc.shimpyo_be.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignInResponseDto {
+
+    private MemberResponseDto member;
+    private TokenResponseDto token;
+
+    @Builder
+    public SignInResponseDto(MemberResponseDto member, TokenResponseDto token) {
+        this.member = member;
+        this.token = token;
+    }
+
+    public static SignInResponseDto of(MemberResponseDto member, TokenResponseDto token) {
+        return SignInResponseDto.builder()
+            .member(member)
+            .token(token)
+            .build();
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/response/TokenResponseDto.java
@@ -1,0 +1,24 @@
+package com.fc.shimpyo_be.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenResponseDto {
+
+    private String grantType;
+    private String accessToken;
+    private long accessTokenExpiresIn;
+    private String refreshToken;
+
+    @Builder
+    public TokenResponseDto(String grantType, String accessToken, long accessTokenExpiresIn,
+        String refreshToken) {
+        this.grantType = grantType;
+        this.accessToken = accessToken;
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/entity/Authority.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/entity/Authority.java
@@ -1,0 +1,6 @@
+package com.fc.shimpyo_be.domain.member.entity;
+
+public enum Authority {
+
+    ROLE_USER
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/entity/Member.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/entity/Member.java
@@ -3,6 +3,8 @@ package com.fc.shimpyo_be.domain.member.entity;
 import com.fc.shimpyo_be.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,7 +21,7 @@ public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(unique = true, nullable = false, length = 3)
+    @Column(unique = true, nullable = false, length = 30)
     private String email;
     @Column(nullable = false, length = 30)
     private String name;
@@ -27,13 +29,17 @@ public class Member extends BaseTimeEntity {
     private String password;
     @Column(nullable = false, columnDefinition = "TEXT")
     private String photoUrl;
+    @Enumerated(EnumType.STRING)
+    private Authority authority;
 
     @Builder
-    public Member(Long id, String email, String name, String password, String photoUrl) {
+    public Member(Long id, String email, String name, String password, String photoUrl,
+        Authority authority) {
         this.id = id;
         this.email = email;
         this.name = name;
         this.password = password;
         this.photoUrl = photoUrl;
+        this.authority = authority;
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/entity/RefreshToken.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/entity/RefreshToken.java
@@ -1,0 +1,30 @@
+package com.fc.shimpyo_be.domain.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RefreshToken {
+
+    @Id
+    @Comment("member_id")
+    private Long id;
+    private String token;
+
+    @Builder
+    public RefreshToken(Long id, String token) {
+        this.id = id;
+        this.token = token;
+    }
+
+    public void updateValue(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/AlreadyExistsMemberException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/AlreadyExistsMemberException.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.exception;
+
+public class AlreadyExistsMemberException extends RuntimeException{
+
+    public AlreadyExistsMemberException(){
+        super("이미 가입된 회원 입니다.");
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException{
+
+    public InvalidRefreshTokenException(){
+        super("Refresh Token 이 유효하지 않습니다.");
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/LoggedOutException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/LoggedOutException.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.exception;
+
+public class LoggedOutException extends RuntimeException{
+
+    public LoggedOutException(){
+        super("로그아웃 된 회원 입니다.");
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.exception;
+
+public class MemberNotFoundException extends RuntimeException{
+
+    public MemberNotFoundException(){
+        super("회원 정보를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/UnmatchedMemberException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/UnmatchedMemberException.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.exception;
+
+public class UnmatchedMemberException extends RuntimeException{
+
+    public UnmatchedMemberException(){
+        super("토큰의 회원 정보가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/UnmatchedPasswordException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/UnmatchedPasswordException.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.exception;
+
+public class UnmatchedPasswordException extends RuntimeException{
+
+    public UnmatchedPasswordException(){
+        super("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/repository/MemberRepository.java
@@ -1,8 +1,12 @@
 package com.fc.shimpyo_be.domain.member.repository;
 
 import com.fc.shimpyo_be.domain.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.repository;
+
+import com.fc.shimpyo_be.domain.member.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/service/AuthService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/service/AuthService.java
@@ -1,0 +1,81 @@
+package com.fc.shimpyo_be.domain.member.service;
+
+import com.fc.shimpyo_be.domain.member.dto.request.RefreshRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignInRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignUpRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.SignInResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.TokenResponseDto;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.entity.RefreshToken;
+import com.fc.shimpyo_be.domain.member.exception.AlreadyExistsMemberException;
+import com.fc.shimpyo_be.domain.member.exception.InvalidRefreshTokenException;
+import com.fc.shimpyo_be.domain.member.exception.LoggedOutException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedMemberException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
+import com.fc.shimpyo_be.domain.member.repository.RefreshTokenRepository;
+import com.fc.shimpyo_be.global.config.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberService memberService;
+
+    public MemberResponseDto signUp(SignUpRequestDto signUpRequestDto) {
+        if (memberService.isExistsByEmail(signUpRequestDto.getEmail())) {
+            throw new AlreadyExistsMemberException();
+        }
+        if (!signUpRequestDto.getPassword().equals(signUpRequestDto.getPasswordConfirm())) {
+            throw new UnmatchedPasswordException();
+        }
+        Member member = signUpRequestDto.toMember(passwordEncoder);
+        return MemberResponseDto.of(memberService.saveMember(member));
+    }
+
+    public SignInResponseDto signIn(SignInRequestDto signInRequestDto) {
+        UsernamePasswordAuthenticationToken authenticationToken = signInRequestDto.toAuthentication();
+        Authentication authentication = authenticationManagerBuilder.getObject()
+            .authenticate(authenticationToken);
+        TokenResponseDto tokenResponseDto = jwtTokenProvider.generateToken(authentication);
+        RefreshToken refreshToken = RefreshToken.builder()
+            .id(Long.parseLong(authentication.getName()))
+            .token(tokenResponseDto.getRefreshToken())
+            .build();
+        refreshTokenRepository.save(refreshToken);
+        return SignInResponseDto.builder().member(MemberResponseDto.of(
+                memberService.getMember(refreshToken.getId())))
+            .token(tokenResponseDto).build();
+    }
+
+    public SignInResponseDto refresh(RefreshRequestDto refreshRequestDto) {
+        if (!jwtTokenProvider.validateToken(refreshRequestDto.getRefreshToken())) {
+            throw new InvalidRefreshTokenException();
+        }
+        Authentication authentication = jwtTokenProvider.getAuthentication(
+            refreshRequestDto.getAccessToken());
+        RefreshToken refreshToken = refreshTokenRepository.findById(
+            Long.parseLong(authentication.getName())).orElseThrow(LoggedOutException::new);
+        if (!refreshToken.getToken().equals(refreshRequestDto.getRefreshToken())) {
+            throw new UnmatchedMemberException();
+        }
+        TokenResponseDto tokenResponseDto = jwtTokenProvider.generateToken(authentication);
+        refreshToken.updateValue(tokenResponseDto.getRefreshToken());
+        return SignInResponseDto.builder()
+            .member(MemberResponseDto.of(memberService.getMember(refreshToken.getId())))
+            .token(tokenResponseDto)
+            .build();
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/service/MemberService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/service/MemberService.java
@@ -1,0 +1,28 @@
+package com.fc.shimpyo_be.domain.member.service;
+
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.exception.MemberNotFoundException;
+import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member saveMember(Member member) {
+        return memberRepository.save(member);
+    }
+
+    public boolean isExistsByEmail(String email) {
+        return memberRepository.existsByEmail(email);
+    }
+
+    public Member getMember(long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/config/CorsConfig.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.fc.shimpyo_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/config/CustomUserDetailsService.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/CustomUserDetailsService.java
@@ -1,0 +1,38 @@
+package com.fc.shimpyo_be.global.config;
+
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberRepository.findByEmail(username)
+            .map(this::createUserDetails)
+            .orElseThrow(() -> new UsernameNotFoundException(username + "을 DB에서 찾을 수 없습니다."));
+    }
+
+    private UserDetails createUserDetails(Member member) {
+        GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(
+            member.getAuthority().toString());
+        return new User(
+            String.valueOf(member.getId()),
+            member.getPassword(),
+            Collections.singleton(grantedAuthority));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.fc.shimpyo_be.global.config;
+
+import com.fc.shimpyo_be.global.config.jwt.JwtAccessDeniedHandler;
+import com.fc.shimpyo_be.global.config.jwt.JwtAuthenticationEntryPoint;
+import com.fc.shimpyo_be.global.config.jwt.JwtAuthenticationFilter;
+import com.fc.shimpyo_be.global.config.jwt.JwtSecurityConfig;
+import com.fc.shimpyo_be.global.config.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig implements WebMvcConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CorsConfig corsConfig;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private static final String[] PERMIT_URL_ARRAY = {
+        "/",
+        "/error",
+        "/docs/**",
+        "/api/auth/**",
+        "/api/products/**"
+    };
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.httpBasic(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(
+                configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests((requests) -> requests
+                .requestMatchers(PERMIT_URL_ARRAY)
+                .permitAll()
+                .anyRequest()
+                .hasRole("USER"))
+            .formLogin(AbstractHttpConfigurer::disable)
+            .addFilter(corsConfig.corsFilter())
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(AuthenticationManager -> AuthenticationManager
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler))
+            .apply(new JwtSecurityConfig(jwtTokenProvider));
+        return http.build();
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.fc.shimpyo_be.global.config.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.fc.shimpyo_be.global.config.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package com.fc.shimpyo_be.global.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null && !token.trim().isEmpty() && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (bearerToken != null && !bearerToken.trim().isEmpty() && bearerToken.startsWith(
+            BEARER_PREFIX)) {
+            return bearerToken.split(" ")[1].trim();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtSecurityConfig.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.fc.shimpyo_be.global.config.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends
+    SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void configure(HttpSecurity builder) throws Exception {
+        JwtAuthenticationFilter customFilter = new JwtAuthenticationFilter(jwtTokenProvider);
+        builder.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,117 @@
+package com.fc.shimpyo_be.global.config.jwt;
+
+import com.fc.shimpyo_be.domain.member.dto.response.TokenResponseDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider implements InitializingBean {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "Bearer";
+    private final String SECRET;
+    private final long ACCESS_TOKEN_EXPIRE_TIME;
+    private final long REFRESH_TOKEN_EXPIRE_TIME;
+    private Key key;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String SECRET,
+        @Value("${jwt.access-token-expire-time}") long ACCESS_TOKEN_EXPIRE_TIME,
+        @Value("${jwt.refresh-token-expire-time}") long REFRESH_TOKEN_EXPIRE_TIME) {
+        this.SECRET = SECRET;
+        this.ACCESS_TOKEN_EXPIRE_TIME = ACCESS_TOKEN_EXPIRE_TIME;
+        this.REFRESH_TOKEN_EXPIRE_TIME = REFRESH_TOKEN_EXPIRE_TIME;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        byte[] keyBytes = Decoders.BASE64.decode(SECRET);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenResponseDto generateToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(","));
+        long now = (new Date()).getTime();
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+            .setSubject(authentication.getName())
+            .claim(AUTHORITIES_KEY, authorities)
+            .setExpiration(accessTokenExpiresIn)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+        String refreshToken = Jwts.builder()
+            .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+        return TokenResponseDto.builder()
+            .grantType(BEARER_TYPE)
+            .accessToken(accessToken)
+            .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+            .refreshToken(refreshToken)
+            .build();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(
+                claims.get(AUTHORITIES_KEY).toString().split(","))
+            .map(SimpleGrantedAuthority::new)
+            .toList();
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못 되었습니다.");
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/fc/shimpyo_be/global/exception/GlobalControllerAdvice.java
@@ -3,6 +3,7 @@ package com.fc.shimpyo_be.global.exception;
 import com.fc.shimpyo_be.global.common.ResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,5 +16,12 @@ public class GlobalControllerAdvice {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
             ResponseDto.res(HttpStatus.BAD_REQUEST,
                 e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> usernameNotFoundException(
+        UsernameNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ResponseDto.res(HttpStatus.NOT_FOUND, e.getMessage()));
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/global/util/SecurityUtil.java
+++ b/src/main/java/com/fc/shimpyo_be/global/util/SecurityUtil.java
@@ -1,0 +1,16 @@
+package com.fc.shimpyo_be.global.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+
+    public static Long getCurrentMemberId() {
+        final Authentication authentication = SecurityContextHolder.getContext()
+            .getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new RuntimeException("Security Context에 인증 정보가 없습니다.");
+        }
+        return Long.parseLong(authentication.getName());
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,3 +12,7 @@ spring:
     redis:
       port: 6379
       host: localhost
+jwt:
+  secret: 7Yyo7Iqk7Yq47Lqg7Y287IqkIOuvuOuLiO2UhOuhnOygne2KuCAxMeyhsCDsibztkZwgSldUIOyLnO2BrOumvyDtgqQ=
+  access-token-expire-time: 1800000
+  refresh-token-expire-time: 604800000

--- a/src/test/java/com/fc/shimpyo_be/domain/member/docs/AuthRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/docs/AuthRestControllerDocsTest.java
@@ -1,0 +1,229 @@
+package com.fc.shimpyo_be.domain.member.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fc.shimpyo_be.config.RestDocsSupport;
+import com.fc.shimpyo_be.domain.member.dto.request.RefreshRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignInRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignUpRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.SignInResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.TokenResponseDto;
+import com.fc.shimpyo_be.domain.member.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class AuthRestControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private AuthService authService;
+
+    private final ConstraintDescriptions signUpDescriptions = new ConstraintDescriptions(
+        SignUpRequestDto.class);
+    private final ConstraintDescriptions signInDescriptions = new ConstraintDescriptions(
+        SignUpRequestDto.class);
+    private final ConstraintDescriptions refreshDescriptions = new ConstraintDescriptions(
+        SignUpRequestDto.class);
+
+    @Test
+    @DisplayName("signUp()은 회원 가입 할 수 있다.")
+    void signUp() throws Exception {
+        // given
+        SignUpRequestDto signUpRequestDto = SignUpRequestDto.builder()
+            .email("test@mail.com")
+            .name("test")
+            .password("qwer1234$$")
+            .passwordConfirm("qwer1234$$")
+            .build();
+        MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+            .memberId(1L)
+            .email("test@mail.com")
+            .name("test")
+            .photoUrl("")
+            .build();
+
+        given(authService.signUp(any(SignUpRequestDto.class))).willReturn(memberResponseDto);
+
+        // when
+        mockMvc.perform(post("/api/auth/signup")
+                .content(objectMapper.writeValueAsString(signUpRequestDto))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andDo(restDoc.document(
+                requestFields(
+                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+                        .attributes(key("constraints").value(
+                            signUpDescriptions.descriptionsForProperty("email"))),
+                    fieldWithPath("name").type(JsonFieldType.STRING).description("이름")
+                        .attributes(key("constraints").value(
+                            signUpDescriptions.descriptionsForProperty("name"))),
+                    fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                        .attributes(key("constraints").value(
+                            signUpDescriptions.descriptionsForProperty("password"))),
+                    fieldWithPath("passwordConfirm").type(JsonFieldType.STRING)
+                        .description("비밀번호 확인").attributes(key("constraints").value(
+                            signUpDescriptions.descriptionsForProperty("passwordConfirm")))),
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
+                    fieldWithPath("data.email").type(JsonFieldType.STRING).description("이메일"),
+                    fieldWithPath("data.name").type(JsonFieldType.STRING).description("이름"),
+                    fieldWithPath("data.photoUrl").type(JsonFieldType.STRING)
+                        .description("프로필 이미지")
+                )
+            ));
+
+        verify(authService, times(1)).signUp(any(SignUpRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("signIn()은 회원 가입 할 수 있다.")
+    void signIn() throws Exception {
+        // given
+        SignInRequestDto signInRequestDto = SignInRequestDto.builder()
+            .email("test@mail.com")
+            .password("qwer1234$$")
+            .build();
+        MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+            .memberId(1L)
+            .email("test@mail.com")
+            .name("test")
+            .photoUrl("")
+            .build();
+        TokenResponseDto tokenResponseDto = TokenResponseDto.builder()
+            .grantType("Bearer")
+            .accessToken(
+                "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+            .accessTokenExpiresIn(1700586928520L)
+            .refreshToken(
+                "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+            .build();
+        SignInResponseDto signInResponseDto = SignInResponseDto.builder()
+            .member(memberResponseDto)
+            .token(tokenResponseDto)
+            .build();
+
+        given(authService.signIn(any(SignInRequestDto.class))).willReturn(signInResponseDto);
+
+        // when
+        mockMvc.perform(post("/api/auth/signin")
+                .content(objectMapper.writeValueAsString(signInRequestDto))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(restDoc.document(
+                requestFields(
+                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+                        .attributes(key("constraints").value(
+                            signInDescriptions.descriptionsForProperty("email"))),
+                    fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                        .attributes(key("constraints").value(
+                            signInDescriptions.descriptionsForProperty("password")))),
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.member").type(JsonFieldType.OBJECT).description("회원 정보"),
+                    fieldWithPath("data.member.memberId").type(JsonFieldType.NUMBER)
+                        .description("회원 식별자"),
+                    fieldWithPath("data.member.email").type(JsonFieldType.STRING)
+                        .description("이메일"),
+                    fieldWithPath("data.member.name").type(JsonFieldType.STRING).description("이름"),
+                    fieldWithPath("data.member.photoUrl").type(JsonFieldType.STRING)
+                        .description("프로필 이미지"),
+                    fieldWithPath("data.token").type(JsonFieldType.OBJECT).description("토큰 정보"),
+                    fieldWithPath("data.token.grantType").type(JsonFieldType.STRING)
+                        .description("권한 부여 유형"),
+                    fieldWithPath("data.token.accessToken").type(JsonFieldType.STRING)
+                        .description("Access Token"),
+                    fieldWithPath("data.token.accessTokenExpiresIn").type(JsonFieldType.NUMBER)
+                        .description("Access Token 만료 날짜"),
+                    fieldWithPath("data.token.refreshToken").type(JsonFieldType.STRING)
+                        .description("Refresh Token")
+                )
+            ));
+
+        verify(authService, times(1)).signIn(any(SignInRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("refresh()는 토큰을 재발급 할 수 있다.")
+    void refresh() throws Exception {
+        // given
+        RefreshRequestDto refreshRequestDto = RefreshRequestDto.builder()
+            .accessToken(
+                "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+            .refreshToken(
+                "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+            .build();
+        MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+            .memberId(1L)
+            .email("test@mail.com")
+            .name("test")
+            .photoUrl("")
+            .build();
+        TokenResponseDto tokenResponseDto = TokenResponseDto.builder()
+            .grantType("Bearer")
+            .accessToken(
+                "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+            .accessTokenExpiresIn(1700586928520L)
+            .refreshToken(
+                "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+            .build();
+        SignInResponseDto signInResponseDto = SignInResponseDto.builder()
+            .member(memberResponseDto)
+            .token(tokenResponseDto)
+            .build();
+
+        given(authService.refresh(any(RefreshRequestDto.class))).willReturn(signInResponseDto);
+
+        // when
+        mockMvc.perform(post("/api/auth/refresh")
+                .content(objectMapper.writeValueAsString(refreshRequestDto))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(restDoc.document(
+                requestFields(
+                    fieldWithPath("accessToken").type(JsonFieldType.STRING)
+                        .description("Access Token")
+                        .attributes(key("constraints").value(
+                            refreshDescriptions.descriptionsForProperty("accessToken"))),
+                    fieldWithPath("refreshToken").type(JsonFieldType.STRING)
+                        .description("Refresh Token")
+                        .attributes(key("constraints").value(
+                            refreshDescriptions.descriptionsForProperty("refreshToken")))),
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.member").type(JsonFieldType.OBJECT).description("회원 정보"),
+                    fieldWithPath("data.member.memberId").type(JsonFieldType.NUMBER)
+                        .description("회원 식별자"),
+                    fieldWithPath("data.member.email").type(JsonFieldType.STRING)
+                        .description("이메일"),
+                    fieldWithPath("data.member.name").type(JsonFieldType.STRING).description("이름"),
+                    fieldWithPath("data.member.photoUrl").type(JsonFieldType.STRING)
+                        .description("프로필 이미지"),
+                    fieldWithPath("data.token").type(JsonFieldType.OBJECT).description("토큰 정보"),
+                    fieldWithPath("data.token.grantType").type(JsonFieldType.STRING)
+                        .description("권한 부여 유형"),
+                    fieldWithPath("data.token.accessToken").type(JsonFieldType.STRING)
+                        .description("Access Token"),
+                    fieldWithPath("data.token.accessTokenExpiresIn").type(JsonFieldType.NUMBER)
+                        .description("Access Token 만료 날짜"),
+                    fieldWithPath("data.token.refreshToken").type(JsonFieldType.STRING)
+                        .description("Refresh Token")
+                )
+            ));
+
+        verify(authService, times(1)).refresh(any(RefreshRequestDto.class));
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/controller/AuthRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/controller/AuthRestControllerTest.java
@@ -1,0 +1,210 @@
+package com.fc.shimpyo_be.domain.member.unit.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.shimpyo_be.domain.member.dto.request.RefreshRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignInRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignUpRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.SignInResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.TokenResponseDto;
+import com.fc.shimpyo_be.domain.member.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    WebApplicationContext context;
+
+    @MockBean
+    AuthService authService;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(this.context)
+            .apply(springSecurity())
+            .build();
+    }
+
+    @Nested
+    @DisplayName("signUp()은")
+    class Context_signUp {
+
+        @Test
+        @DisplayName("회원 가입 할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            SignUpRequestDto request = SignUpRequestDto.builder()
+                .email("test@mail.com")
+                .name("test")
+                .password("qwer1234$$")
+                .passwordConfirm("qwer1234$$")
+                .build();
+            MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+                .memberId(1L)
+                .email("test@mail.com")
+                .name("test")
+                .photoUrl("")
+                .build();
+
+            given(authService.signUp(any(SignUpRequestDto.class))).willReturn(memberResponseDto);
+
+            // when then
+            mockMvc.perform(post("/api/auth/signup")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").isNumber())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.memberId").isNumber())
+                .andExpect(jsonPath("$.data.email").isString())
+                .andExpect(jsonPath("$.data.name").isString())
+                .andExpect(jsonPath("$.data.photoUrl").isString())
+                .andDo(print());
+            verify(authService, times(1)).signUp(any(SignUpRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("signIn()은")
+    class Context_signIn {
+
+        @Test
+        @DisplayName("로그인 할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            SignInRequestDto request = SignInRequestDto.builder()
+                .email("test@mail.com")
+                .password("qwer1234$$")
+                .build();
+            MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+                .memberId(1L)
+                .email("test@mail.com")
+                .name("test")
+                .photoUrl("")
+                .build();
+            TokenResponseDto tokenResponseDto = TokenResponseDto.builder()
+                .grantType("Bearer")
+                .accessToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+                .accessTokenExpiresIn(1700586928520L)
+                .refreshToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+            SignInResponseDto signInResponseDto = SignInResponseDto.builder()
+                .member(memberResponseDto)
+                .token(tokenResponseDto)
+                .build();
+
+            given(authService.signIn(any(SignInRequestDto.class))).willReturn(signInResponseDto);
+
+            // when then
+            mockMvc.perform(post("/api/auth/signin")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").isNumber())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.member").isMap())
+                .andExpect(jsonPath("$.data.member.memberId").isNumber())
+                .andExpect(jsonPath("$.data.member.email").isString())
+                .andExpect(jsonPath("$.data.member.name").isString())
+                .andExpect(jsonPath("$.data.member.photoUrl").isString())
+                .andExpect(jsonPath("$.data.token").isMap())
+                .andExpect(jsonPath("$.data.token.grantType").isString())
+                .andExpect(jsonPath("$.data.token.accessToken").isString())
+                .andExpect(jsonPath("$.data.token.accessTokenExpiresIn").isNumber())
+                .andExpect(jsonPath("$.data.token.refreshToken").isString())
+                .andDo(print());
+            verify(authService, times(1)).signIn(any(SignInRequestDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("refresh()은")
+    class Context_refresh {
+
+        @Test
+        @DisplayName("토큰을 재발급 할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            RefreshRequestDto request = RefreshRequestDto.builder()
+                .accessToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+                .refreshToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+            MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+                .memberId(1L)
+                .email("test@mail.com")
+                .name("test")
+                .photoUrl("")
+                .build();
+            TokenResponseDto tokenResponseDto = TokenResponseDto.builder()
+                .grantType("Bearer")
+                .accessToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+                .accessTokenExpiresIn(1700586928520L)
+                .refreshToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+            SignInResponseDto signInResponseDto = SignInResponseDto.builder()
+                .member(memberResponseDto)
+                .token(tokenResponseDto)
+                .build();
+
+            given(authService.refresh(any(RefreshRequestDto.class))).willReturn(signInResponseDto);
+
+            // when then
+            mockMvc.perform(post("/api/auth/refresh")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").isNumber())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.member").isMap())
+                .andExpect(jsonPath("$.data.member.memberId").isNumber())
+                .andExpect(jsonPath("$.data.member.email").isString())
+                .andExpect(jsonPath("$.data.member.name").isString())
+                .andExpect(jsonPath("$.data.member.photoUrl").isString())
+                .andExpect(jsonPath("$.data.token").isMap())
+                .andExpect(jsonPath("$.data.token.grantType").isString())
+                .andExpect(jsonPath("$.data.token.accessToken").isString())
+                .andExpect(jsonPath("$.data.token.accessTokenExpiresIn").isNumber())
+                .andExpect(jsonPath("$.data.token.refreshToken").isString())
+                .andDo(print());
+            verify(authService, times(1)).refresh(any(RefreshRequestDto.class));
+        }
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/repository/MemberRepositoryTest.java
@@ -1,0 +1,156 @@
+package com.fc.shimpyo_be.domain.member.unit.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fc.shimpyo_be.config.TestJpaConfig;
+import com.fc.shimpyo_be.domain.member.entity.Authority;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({TestJpaConfig.class})
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+public class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    public void reset() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        memberRepository.deleteAll();
+        entityManager.createNativeQuery("TRUNCATE TABLE member").executeUpdate();
+        entityManager
+            .createNativeQuery("ALTER TABLE member ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private void saveMember() {
+        Member member = Member.builder()
+            .email("test@mail.com")
+            .name("test")
+            .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+            .photoUrl(
+                "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+            .authority(Authority.ROLE_USER)
+            .build();
+        memberRepository.save(member);
+    }
+
+    @Nested
+    @DisplayName("save()는")
+    class Context_save {
+
+        @Test
+        @DisplayName("회원 정보를 저장할 수 있다.")
+        void _willSuccess() {
+            // given
+            Member member = Member.builder()
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl("")
+                .authority(Authority.ROLE_USER)
+                .build();
+
+            // when
+            Member result = memberRepository.save(member);
+
+            // then
+            assertThat(result.getId()).isNotNull();
+            assertThat(result.getEmail()).isEqualTo("test@mail.com");
+            assertThat(result.getName()).isEqualTo("test");
+            assertThat(result.getPassword()).isEqualTo(
+                "$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm");
+            assertThat(result.getPhotoUrl()).isEqualTo("");
+            assertThat(result.getAuthority()).isEqualTo(Authority.ROLE_USER);
+        }
+    }
+
+    @Nested
+    @DisplayName("findById()는")
+    class Context_findById {
+
+        @Test
+        @DisplayName("ID 로 회원 정보를 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            saveMember();
+
+            // when
+            Optional<Member> result = memberRepository.findById(1L);
+
+            // then
+            assertThat(result.isPresent()).isTrue();
+            assertThat(result.get().getId()).isNotNull();
+            assertThat(result.get().getEmail()).isEqualTo("test@mail.com");
+            assertThat(result.get().getName()).isEqualTo("test");
+            assertThat(result.get().getPassword()).isEqualTo(
+                "$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm");
+            assertThat(result.get().getPhotoUrl()).isEqualTo(
+                "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI");
+            assertThat(result.get().getAuthority()).isEqualTo(Authority.ROLE_USER);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByEmail()는")
+    class Context_findByEmail {
+
+        @Test
+        @DisplayName("Email 로 회원 정보를 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            saveMember();
+
+            // when
+            Optional<Member> result = memberRepository.findByEmail("test@mail.com");
+
+            // then
+            assertThat(result.isPresent()).isTrue();
+            assertThat(result.get().getId()).isNotNull();
+            assertThat(result.get().getEmail()).isEqualTo("test@mail.com");
+            assertThat(result.get().getName()).isEqualTo("test");
+            assertThat(result.get().getPassword()).isEqualTo(
+                "$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm");
+            assertThat(result.get().getPhotoUrl()).isEqualTo(
+                "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI");
+            assertThat(result.get().getAuthority()).isEqualTo(Authority.ROLE_USER);
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByEmail()는")
+    class Context_existsByEmail {
+
+        @Test
+        @DisplayName("Email 에 해당하는 회원 정보 존재 여부를 확인할 수 있다.")
+        void _willSuccess() {
+            // given
+            saveMember();
+
+            // when
+            boolean result = memberRepository.existsByEmail("test@mail.com");
+
+            // then
+            assertThat(result).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.fc.shimpyo_be.domain.member.unit.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fc.shimpyo_be.config.TestJpaConfig;
+import com.fc.shimpyo_be.domain.member.entity.RefreshToken;
+import com.fc.shimpyo_be.domain.member.repository.RefreshTokenRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({TestJpaConfig.class})
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+public class RefreshTokenRepositoryTest {
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    public void reset() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        refreshTokenRepository.deleteAll();
+        entityManager.createNativeQuery("TRUNCATE TABLE refresh_token").executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private void saveRefreshToken() {
+        RefreshToken refreshToken = RefreshToken.builder()
+            .id(1L)
+            .token(
+                "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-u")
+            .build();
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    @Nested
+    @DisplayName("save()는")
+    class Context_save {
+
+        @Test
+        @DisplayName("Refresh Token 을 저장할 수 있다.")
+        void _willSuccess() {
+            // given
+            RefreshToken refreshToken = RefreshToken.builder()
+                .id(1L)
+                .token(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-u")
+                .build();
+
+            // when
+            RefreshToken result = refreshTokenRepository.save(refreshToken);
+
+            // then
+            assertThat(result.getId()).isNotNull();
+            assertThat(result.getToken()).isEqualTo(
+                "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-u");
+        }
+    }
+
+    @Nested
+    @DisplayName("findById()는")
+    class Context_findById {
+
+        @Test
+        @DisplayName("ID로 Refresh Token 을 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            saveRefreshToken();
+
+            // when
+            Optional<RefreshToken> result = refreshTokenRepository.findById(1L);
+
+            // then
+            assertThat(result.isPresent()).isTrue();
+            assertThat(result.get().getId()).isNotNull();
+            assertThat(result.get().getToken()).isEqualTo(
+                "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-u");
+        }
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/service/AuthServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/service/AuthServiceTest.java
@@ -1,0 +1,390 @@
+package com.fc.shimpyo_be.domain.member.unit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fc.shimpyo_be.domain.member.dto.request.RefreshRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignInRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.SignUpRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.SignInResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.TokenResponseDto;
+import com.fc.shimpyo_be.domain.member.entity.Authority;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.entity.RefreshToken;
+import com.fc.shimpyo_be.domain.member.exception.AlreadyExistsMemberException;
+import com.fc.shimpyo_be.domain.member.exception.InvalidRefreshTokenException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedMemberException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
+import com.fc.shimpyo_be.domain.member.repository.RefreshTokenRepository;
+import com.fc.shimpyo_be.domain.member.service.AuthService;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
+import com.fc.shimpyo_be.global.config.jwt.JwtTokenProvider;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Nested
+    @DisplayName("signUp()은")
+    class Context_signUp {
+
+        @Test
+        @DisplayName("회원 가입을 할 수 있다.")
+        void _willSuccess() {
+            // given
+            SignUpRequestDto signUpRequestDto = SignUpRequestDto.builder()
+                .email("test@mail.com")
+                .name("test")
+                .password("qwer1234$$")
+                .passwordConfirm("qwer1234$$")
+                .build();
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl("")
+                .authority(Authority.ROLE_USER)
+                .build();
+
+            given(memberService.isExistsByEmail(any(String.class))).willReturn(false);
+            given(passwordEncoder.encode(any(String.class)))
+                .willReturn("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm");
+            given(memberService.saveMember(any(Member.class))).willReturn(member);
+
+            // when
+            MemberResponseDto result = authService.signUp(signUpRequestDto);
+
+            // then
+            assertNotNull(result);
+            assertThat(result).extracting("memberId", "email", "name", "photoUrl")
+                .containsExactly(1L, "test@mail.com", "test", "");
+
+            verify(memberService, times(1)).isExistsByEmail(any(String.class));
+            verify(passwordEncoder, times(1)).encode(any(String.class));
+            verify(memberService, times(1)).saveMember(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("이미 회원 가입한 회원은 회원 가입을 할 수 없다.")
+        void alreadyExistsMember_willFail() {
+            // given
+            SignUpRequestDto signUpRequestDto = SignUpRequestDto.builder()
+                .email("test@mail.com")
+                .name("test")
+                .password("qwer1234$$")
+                .passwordConfirm("qwer1234$$")
+                .build();
+
+            given(memberService.isExistsByEmail(any(String.class))).willReturn(true);
+
+            // when
+            Throwable exception = assertThrows(AlreadyExistsMemberException.class, () -> {
+                authService.signUp(signUpRequestDto);
+            });
+
+            // then
+            assertEquals("이미 가입된 회원 입니다.", exception.getMessage());
+
+            verify(memberService, times(1)).isExistsByEmail(any(String.class));
+            verify(memberService, never()).saveMember(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 로그인을 할 수 없다.")
+        void unmatchedPassword_willFail() {
+            // given
+            SignUpRequestDto signUpRequestDto = SignUpRequestDto.builder()
+                .email("test@mail.com")
+                .name("test")
+                .password("qwer1234$$")
+                .passwordConfirm("qwer1234$")
+                .build();
+
+            given(memberService.isExistsByEmail(any(String.class))).willReturn(false);
+
+            // when
+            Throwable exception = assertThrows(UnmatchedPasswordException.class, () -> {
+                authService.signUp(signUpRequestDto);
+            });
+
+            // then
+            assertEquals("비밀번호와 비밀번호 확인이 일치하지 않습니다.", exception.getMessage());
+
+            verify(memberService, times(1)).isExistsByEmail(any(String.class));
+            verify(memberService, never()).saveMember(any(Member.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("signIn()은")
+    class Context_signIn {
+
+        @Test
+        @DisplayName("로그인을 할 수 있다.")
+        void _willSuccess() {
+            // given
+            SignInRequestDto signInRequestDto = SignInRequestDto.builder()
+                .email("test@mail.com")
+                .password("qwer1234$$")
+                .build();
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_USER)
+                .build();
+            UserDetails principal = new User(String.valueOf(member.getId()), "",
+                Arrays.stream(new String[]{member.getAuthority().name()})
+                    .map(SimpleGrantedAuthority::new)
+                    .toList());
+            Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "",
+                Arrays.stream(new String[]{member.getAuthority().name()})
+                    .map(SimpleGrantedAuthority::new)
+                    .toList());
+            TokenResponseDto tokenResponseDto = TokenResponseDto.builder()
+                .grantType("Bearer")
+                .accessToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+                .accessTokenExpiresIn(1700586928520L)
+                .refreshToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+            RefreshToken refreshToken = RefreshToken.builder()
+                .id(1L)
+                .token(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+
+            given(authenticationManagerBuilder.getObject()).willReturn(authenticationManager);
+            given(authenticationManager.authenticate(any(Authentication.class))).willReturn(
+                authentication);
+            given(jwtTokenProvider.generateToken(any(Authentication.class))).willReturn(
+                tokenResponseDto);
+            given(refreshTokenRepository.save(any(RefreshToken.class))).willReturn(refreshToken);
+            given(memberService.getMember(any(long.class))).willReturn(member);
+
+            // when
+            SignInResponseDto result = authService.signIn(signInRequestDto);
+
+            // then
+            assertNotNull(result);
+            assertThat(result.getMember()).extracting("memberId", "email", "name", "photoUrl")
+                .containsExactly(1L, "test@mail.com", "test",
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI");
+            assertThat(result.getToken()).extracting("grantType", "accessToken",
+                    "accessTokenExpiresIn", "refreshToken")
+                .containsExactly("Bearer",
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg",
+                    1700586928520L,
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA");
+
+            verify(authenticationManagerBuilder, times(1)).getObject();
+            verify(authenticationManager, times(1)).authenticate(any(Authentication.class));
+            verify(jwtTokenProvider, times(1)).generateToken(any(Authentication.class));
+            verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+            verify(memberService, times(1)).getMember(any(long.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("refresh()은")
+    class Context_refresh {
+
+        @Test
+        @DisplayName("토큰을 재발급 할 수 있다.")
+        void _willSuccess() {
+            // given
+            RefreshRequestDto refreshRequestDto = RefreshRequestDto.builder()
+                .accessToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+                .refreshToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_USER)
+                .build();
+            UserDetails principal = new User(String.valueOf(member.getId()), "",
+                Arrays.stream(new String[]{member.getAuthority().name()})
+                    .map(SimpleGrantedAuthority::new)
+                    .toList());
+            Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "",
+                Arrays.stream(new String[]{member.getAuthority().name()})
+                    .map(SimpleGrantedAuthority::new)
+                    .toList());
+            TokenResponseDto tokenResponseDto = TokenResponseDto.builder()
+                .grantType("Bearer")
+                .accessToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+                .accessTokenExpiresIn(1700586928520L)
+                .refreshToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+            RefreshToken refreshToken = RefreshToken.builder()
+                .id(1L)
+                .token(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+
+            given(jwtTokenProvider.validateToken(any(String.class))).willReturn(true);
+            given(jwtTokenProvider.getAuthentication(any(String.class))).willReturn(authentication);
+            given(refreshTokenRepository.findById(any(Long.class))).willReturn(
+                Optional.of(refreshToken));
+            given(jwtTokenProvider.generateToken(any(Authentication.class))).willReturn(
+                tokenResponseDto);
+            given(memberService.getMember(any(long.class))).willReturn(member);
+
+            // when
+            SignInResponseDto result = authService.refresh(refreshRequestDto);
+
+            // then
+            assertNotNull(result);
+            assertThat(result.getMember()).extracting("memberId", "email", "name", "photoUrl")
+                .containsExactly(1L, "test@mail.com", "test",
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI");
+            assertThat(result.getToken()).extracting("grantType", "accessToken",
+                    "accessTokenExpiresIn", "refreshToken")
+                .containsExactly("Bearer",
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg",
+                    1700586928520L,
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA");
+
+            verify(jwtTokenProvider, times(1)).validateToken(any(String.class));
+            verify(jwtTokenProvider, times(1)).getAuthentication(any(String.class));
+            verify(refreshTokenRepository, times(1)).findById(any(Long.class));
+            verify(jwtTokenProvider, times(1)).generateToken(any(Authentication.class));
+            verify(memberService, times(1)).getMember(any(long.class));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 refresh 토큰이라면, 토큰을 재발급 할 수 없다.")
+        void invalidToken_willFail() {
+            // given
+            RefreshRequestDto refreshRequestDto = RefreshRequestDto.builder()
+                .accessToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+                .refreshToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+
+            given(jwtTokenProvider.validateToken(any(String.class))).willReturn(false);
+
+            // when
+            Throwable exception = assertThrows(InvalidRefreshTokenException.class, () -> {
+                authService.refresh(refreshRequestDto);
+            });
+
+            // then
+            assertEquals("Refresh Token 이 유효하지 않습니다.", exception.getMessage());
+
+            verify(jwtTokenProvider, times(1)).validateToken(any(String.class));
+        }
+
+        @Test
+        @DisplayName("DB에 있는 Refresh 토큰과 일치하지 않는다면, 토큰을 재발급 할 수 없다.")
+        void unmatchedMember_willFail() {
+            // given
+            RefreshRequestDto refreshRequestDto = RefreshRequestDto.builder()
+                .accessToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiYXV0aCI6IlJPTEVfVVNFUiIsImV4cCI6MTcwMDU4NjkyOH0.lof7WjalCH1gGPy2q7YYi9VTcgn_aoFMwEMQvITtddsUIcJN-YzNODt_RQde5J5dH98NKMXDOvy7YwNlt6BCfg")
+                .refreshToken(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-uA")
+                .build();
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_USER)
+                .build();
+            UserDetails principal = new User(String.valueOf(member.getId()), "",
+                Arrays.stream(new String[]{member.getAuthority().name()})
+                    .map(SimpleGrantedAuthority::new)
+                    .toList());
+            Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "",
+                Arrays.stream(new String[]{member.getAuthority().name()})
+                    .map(SimpleGrantedAuthority::new)
+                    .toList());
+            RefreshToken refreshToken = RefreshToken.builder()
+                .id(1L)
+                .token(
+                    "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3MDExODk5Mjh9.uZuIAxsnf4Ubz5K9YzysJTu9Gh25XNTsPVAPSElw1lS78gS8S08L97Z4RkfGodegGXZ9UFFNkVXdhRzF9Pr-u")
+                .build();
+
+            given(jwtTokenProvider.validateToken(any(String.class))).willReturn(true);
+            given(jwtTokenProvider.getAuthentication(any(String.class))).willReturn(authentication);
+            given(refreshTokenRepository.findById(any(Long.class))).willReturn(
+                Optional.of(refreshToken));
+
+            // when
+            Throwable exception = assertThrows(UnmatchedMemberException.class, () -> {
+                authService.refresh(refreshRequestDto);
+            });
+
+            // then
+            assertEquals("토큰의 회원 정보가 일치하지 않습니다.", exception.getMessage());
+
+            verify(jwtTokenProvider, times(1)).validateToken(any(String.class));
+            verify(jwtTokenProvider, times(1)).getAuthentication(any(String.class));
+            verify(refreshTokenRepository, times(1)).findById(any(Long.class));
+        }
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,8 +3,11 @@ spring:
     include: test
   datasource:
     driver-class-name: org.h2.Driver
-
   data:
     redis:
       host: localhost
       port: 6379
+jwt:
+  secret: 7Yyo7Iqk7Yq47Lqg7Y287IqkIOuvuOuLiO2UhOuhnOygne2KuCAxMeyhsCDsibztkZwgSldUIOyLnO2BrOumvyDtgqQ=
+  access-token-expire-time: 1800000
+  refresh-token-expire-time: 604800000


### PR DESCRIPTION
### 💡 Motivation
- Security와 JWT 설정이 필요합니다. 
- 회원 가입, 로그인, 토큰 재발급 기능을 구현해야 합니다. 

### 📌 Changes
- Security, JWT 설정
- 회원 가입 기능 구현
- 로그인 기능 구현
- 토큰 재발급 기능 구현
- 구현한 기능 테스트 코드 작성
- REST Docs 테스트 코드 작성

### 🫱🏻‍🫲🏻 To Reviewers
- REST Docs를 위한 테스트 코드를 작성했습니다! adoc 파일은 추후 추가할 예정이니, 참고하셔서 리뷰 부탁드립니다~

This close #6 