### PR TITLE
feat: 회원 정보 수정 기능 구현 및 회원 API 문서

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,31 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= 쉼표 API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+
+== API
+
+=== link:member/member-api.html[회원 API, window=blank]
+
+== API Common Response
+
+[[overview-http-status-code]]
+=== 1. HTTP Status Code
+
+|===
+| Status code | Useage
+| `200 OK` | 요청을 성공적으로 수행
+| `201 Created` | 생성 요청 (ex: 여행 등록)을 성공적으로 수행
+| `400 Bad Request` | API 에 기술되어 있는 요구사항에 부적합 시 발생
+| `401 Unauthorized` | 해당 API에 대한 인증 정보가 없는 경우 발생
+| `403 Forbiddon` | 해당 API에 대한 권한이 없는 경우 발생
+| `404 NotFound` | 지원하지 않는 API 경로로 요청 시 발생
+| `500 Internal Server Error` | 내부 서버 에러
+|===

--- a/src/docs/asciidoc/member/member-api.adoc
+++ b/src/docs/asciidoc/member/member-api.adoc
@@ -1,0 +1,51 @@
+= Trip REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+[[Sign-Up]]
+== 회원 가입
+
+회원 가입 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/auth-rest-controller-docs-test/sign-up/http-request.adoc[]
+include::{snippets}/auth-rest-controller-docs-test/sign-up/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/auth-rest-controller-docs-test/sign-up/http-response.adoc[]
+include::{snippets}/auth-rest-controller-docs-test/sign-up/response-fields.adoc[]
+
+[[Sign-In]]
+== 로그인
+
+로그인 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/auth-rest-controller-docs-test/sign-in/http-request.adoc[]
+include::{snippets}/auth-rest-controller-docs-test/sign-in/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/auth-rest-controller-docs-test/sign-in/http-response.adoc[]
+include::{snippets}/auth-rest-controller-docs-test/sign-in/response-fields.adoc[]
+
+[[Update-Member]]
+== 회원 정보 수정
+
+회원 정보 수정 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/member-rest-controller-docs-test/update-member/http-request.adoc[]
+include::{snippets}/member-rest-controller-docs-test/update-member/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/member-rest-controller-docs-test/update-member/http-response.adoc[]
+include::{snippets}/member-rest-controller-docs-test/update-member/response-fields.adoc[]

--- a/src/main/java/com/fc/shimpyo_be/domain/member/controller/AuthRestControllerAdvice.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/controller/AuthRestControllerAdvice.java
@@ -16,13 +16,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class AuthRestControllerAdvice {
 
     @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> MemberNotFoundException(
-        MemberNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(ResponseDto.res(HttpStatus.NOT_FOUND, e.getMessage()));
-    }
-
-    @ExceptionHandler
     public ResponseEntity<ResponseDto<Void>> alreadySignUpException(
         AlreadyExistsMemberException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -46,13 +39,6 @@ public class AuthRestControllerAdvice {
     @ExceptionHandler
     public ResponseEntity<ResponseDto<Void>> unmatchedMemberException(
         UnmatchedMemberException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> unmatchedPasswordException(
-        UnmatchedPasswordException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
     }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/controller/MemberRestController.java
@@ -1,0 +1,40 @@
+package com.fc.shimpyo_be.domain.member.controller;
+
+import com.fc.shimpyo_be.domain.member.dto.request.CheckPasswordRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.UpdateMemberRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.CheckPasswordResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
+import com.fc.shimpyo_be.global.common.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberRestController {
+
+    private final MemberService memberService;
+
+    @PatchMapping
+    public ResponseEntity<ResponseDto<MemberResponseDto>> updateMember(@RequestBody
+    UpdateMemberRequestDto updateMemberRequestDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDto.res(HttpStatus.OK, memberService.updateMember(updateMemberRequestDto),
+                "성공적으로 회원 정보를 수정했습니다."));
+    }
+
+    @PostMapping
+    public ResponseEntity<ResponseDto<CheckPasswordResponseDto>> checkPassword(
+        @RequestBody CheckPasswordRequestDto checkPasswordRequestDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDto.res(HttpStatus.OK, memberService.checkPassword(checkPasswordRequestDto),
+                "비밀번호가 일치합니다."));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/controller/MemberRestControllerAdvice.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/controller/MemberRestControllerAdvice.java
@@ -1,0 +1,43 @@
+package com.fc.shimpyo_be.domain.member.controller;
+
+import com.fc.shimpyo_be.domain.member.exception.InvalidPasswordException;
+import com.fc.shimpyo_be.domain.member.exception.MemberNotFoundException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
+import com.fc.shimpyo_be.domain.member.exception.WrongPasswordException;
+import com.fc.shimpyo_be.global.common.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MemberRestControllerAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> MemberNotFoundException(
+        MemberNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ResponseDto.res(HttpStatus.NOT_FOUND, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> wrongPasswordException(
+        WrongPasswordException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> invalidPasswordException(
+        InvalidPasswordException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDto<Void>> unmatchedPasswordException(
+        UnmatchedPasswordException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/CheckPasswordRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/CheckPasswordRequestDto.java
@@ -1,0 +1,19 @@
+package com.fc.shimpyo_be.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckPasswordRequestDto {
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    private String password;
+
+    @Builder
+    public CheckPasswordRequestDto(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/UpdateMemberRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/request/UpdateMemberRequestDto.java
@@ -1,0 +1,21 @@
+package com.fc.shimpyo_be.domain.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateMemberRequestDto {
+
+    private String password;
+    private String passwordConfirm;
+    private String photoUrl;
+
+    @Builder
+    public UpdateMemberRequestDto(String password, String passwordConfirm, String photoUrl) {
+        this.password = password;
+        this.passwordConfirm = passwordConfirm;
+        this.photoUrl = photoUrl;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/dto/response/CheckPasswordResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/dto/response/CheckPasswordResponseDto.java
@@ -1,0 +1,17 @@
+package com.fc.shimpyo_be.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckPasswordResponseDto {
+
+    private boolean isCorrectPassword;
+
+    @Builder
+    public CheckPasswordResponseDto(boolean isCorrectPassword) {
+        this.isCorrectPassword = isCorrectPassword;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/entity/Member.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.fc.shimpyo_be.domain.member.entity;
 
+import com.fc.shimpyo_be.domain.member.dto.request.UpdateMemberRequestDto;
 import com.fc.shimpyo_be.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,5 +42,15 @@ public class Member extends BaseTimeEntity {
         this.password = password;
         this.photoUrl = photoUrl;
         this.authority = authority;
+    }
+
+    public void update(UpdateMemberRequestDto updateMemberRequestDto) {
+        if (updateMemberRequestDto.getPhotoUrl() != null) {
+            this.photoUrl = updateMemberRequestDto.getPhotoUrl();
+        }
+    }
+
+    public void changePassword(String password){
+        this.password = password;
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/InvalidPasswordException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/InvalidPasswordException.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.exception;
+
+public class InvalidPasswordException extends RuntimeException{
+
+    public InvalidPasswordException() {
+        super("비밀번호 양식에 맞지 않습니다.");
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/WrongPasswordException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/WrongPasswordException.java
@@ -1,0 +1,8 @@
+package com.fc.shimpyo_be.domain.member.exception;
+
+public class WrongPasswordException extends RuntimeException{
+
+    public WrongPasswordException(){
+        super("비밀번호가 틀렸습니다.");
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/member/service/AuthService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/service/AuthService.java
@@ -12,7 +12,6 @@ import com.fc.shimpyo_be.domain.member.exception.AlreadyExistsMemberException;
 import com.fc.shimpyo_be.domain.member.exception.InvalidRefreshTokenException;
 import com.fc.shimpyo_be.domain.member.exception.LoggedOutException;
 import com.fc.shimpyo_be.domain.member.exception.UnmatchedMemberException;
-import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
 import com.fc.shimpyo_be.domain.member.repository.RefreshTokenRepository;
 import com.fc.shimpyo_be.global.config.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -38,9 +37,9 @@ public class AuthService {
         if (memberService.isExistsByEmail(signUpRequestDto.getEmail())) {
             throw new AlreadyExistsMemberException();
         }
-        if (!signUpRequestDto.getPassword().equals(signUpRequestDto.getPasswordConfirm())) {
-            throw new UnmatchedPasswordException();
-        }
+        memberService.checkValidPassword(signUpRequestDto.getPassword());
+        memberService.checkMatchedPassword(signUpRequestDto.getPassword(),
+            signUpRequestDto.getPasswordConfirm());
         Member member = signUpRequestDto.toMember(passwordEncoder);
         return MemberResponseDto.of(memberService.saveMember(member));
     }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/service/MemberService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/service/MemberService.java
@@ -1,9 +1,19 @@
 package com.fc.shimpyo_be.domain.member.service;
 
+import com.fc.shimpyo_be.domain.member.dto.request.CheckPasswordRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.UpdateMemberRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.CheckPasswordResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
 import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.exception.InvalidPasswordException;
 import com.fc.shimpyo_be.domain.member.exception.MemberNotFoundException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
+import com.fc.shimpyo_be.domain.member.exception.WrongPasswordException;
 import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +23,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SecurityUtil securityUtil;
+    private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$#^()!%*?&])[A-Za-z\\d@$!#^()%*?&]{8,30}$";
 
     public Member saveMember(Member member) {
         return memberRepository.save(member);
@@ -24,5 +37,47 @@ public class MemberService {
 
     public Member getMember(long memberId) {
         return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    }
+
+    public MemberResponseDto updateMember(UpdateMemberRequestDto updateMemberRequestDto) {
+        Member member = getMember(securityUtil.getCurrentMemberId());
+        member.update(updateMemberRequestDto);
+        if (updateMemberRequestDto.getPassword() != null) {
+            updatePassword(member, updateMemberRequestDto);
+        }
+        return MemberResponseDto.of(member);
+    }
+
+    public CheckPasswordResponseDto checkPassword(CheckPasswordRequestDto checkPasswordRequestDto) {
+        Member member = getMember(securityUtil.getCurrentMemberId());
+        checkCorrectPassword(member, checkPasswordRequestDto.getPassword());
+        return CheckPasswordResponseDto.builder()
+            .isCorrectPassword(true)
+            .build();
+    }
+
+    private void updatePassword(Member member, UpdateMemberRequestDto updateMemberRequestDto) {
+        checkValidPassword(updateMemberRequestDto.getPassword());
+        checkMatchedPassword(updateMemberRequestDto.getPassword(),
+            updateMemberRequestDto.getPasswordConfirm());
+        member.changePassword(passwordEncoder.encode(updateMemberRequestDto.getPassword()));
+    }
+
+    public void checkCorrectPassword(Member member, String password) {
+        if (!member.getPassword().equals(password)) {
+            throw new WrongPasswordException();
+        }
+    }
+
+    public void checkMatchedPassword(String password, String passwordConfirm) {
+        if (!password.equals(passwordConfirm)) {
+            throw new UnmatchedPasswordException();
+        }
+    }
+
+    public void checkValidPassword(String password) {
+        if (!Pattern.matches(PASSWORD_REGEX, password)) {
+            throw new InvalidPasswordException();
+        }
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/global/util/SecurityUtil.java
+++ b/src/main/java/com/fc/shimpyo_be/global/util/SecurityUtil.java
@@ -2,10 +2,12 @@ package com.fc.shimpyo_be.global.util;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 
+@Component
 public class SecurityUtil {
 
-    public static Long getCurrentMemberId() {
+    public Long getCurrentMemberId() {
         final Authentication authentication = SecurityContextHolder.getContext()
             .getAuthentication();
         if (authentication == null || authentication.getName() == null) {

--- a/src/test/java/com/fc/shimpyo_be/domain/member/docs/MemberRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/docs/MemberRestControllerDocsTest.java
@@ -1,0 +1,112 @@
+package com.fc.shimpyo_be.domain.member.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+
+import com.fc.shimpyo_be.config.RestDocsSupport;
+import com.fc.shimpyo_be.domain.member.dto.request.CheckPasswordRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.UpdateMemberRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.CheckPasswordResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class MemberRestControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private MemberService memberService;
+
+    private final ConstraintDescriptions CheckPasswordDescriptions = new ConstraintDescriptions(
+        CheckPasswordRequestDto.class);
+
+    @Test
+    @DisplayName("updateMember()은 회원 정보를 수정할 수 있다.")
+    @WithMockUser(roles = "USER")
+    void updateMember() throws Exception {
+        // given
+        UpdateMemberRequestDto request = UpdateMemberRequestDto.builder()
+            .photoUrl(
+                "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+            .build();
+        MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+            .memberId(1L)
+            .email("test@mail.com")
+            .name("test")
+            .photoUrl(
+                "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+            .build();
+
+        given(memberService.updateMember(any(UpdateMemberRequestDto.class))).willReturn(
+            memberResponseDto);
+
+        // when then
+        mockMvc.perform(patch("/api/members")
+                .with(csrf())
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(restDoc.document(
+                requestFields(
+                    fieldWithPath("password").type(JsonFieldType.STRING).optional()
+                        .description("비밀번호"),
+                    fieldWithPath("passwordConfirm").type(JsonFieldType.STRING).optional()
+                        .description("비밀번호 확인"),
+                    fieldWithPath("photoUrl").type(JsonFieldType.STRING).optional()
+                        .description("프로필 이미지")),
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
+                    fieldWithPath("data.email").type(JsonFieldType.STRING).description("이메일"),
+                    fieldWithPath("data.name").type(JsonFieldType.STRING).description("이름"),
+                    fieldWithPath("data.photoUrl").type(JsonFieldType.STRING)
+                        .description("프로필 이미지")
+                ))
+            );
+    }
+
+    @Test
+    @DisplayName("checkPassword()은 비밀번호가 일치하는지 확인할 수 있다.")
+    @WithMockUser(roles = "USER")
+    void _willSuccess() throws Exception {
+        // given
+        CheckPasswordRequestDto request = CheckPasswordRequestDto.builder()
+            .password("qwer1234$$")
+            .build();
+        CheckPasswordResponseDto checkPasswordResponseDto = CheckPasswordResponseDto.builder()
+            .isCorrectPassword(true)
+            .build();
+
+        given(memberService.checkPassword(any(CheckPasswordRequestDto.class))).willReturn(
+            checkPasswordResponseDto);
+
+        // when then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/members")
+                .with(csrf())
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(restDoc.document(
+                requestFields(
+                    fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                        .attributes(key("constraints").value(
+                            CheckPasswordDescriptions.descriptionsForProperty("password")))),
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.correctPassword").type(JsonFieldType.BOOLEAN)
+                        .description("회원 식별자")
+                ))
+            );
+    }
+
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/controller/MemberRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/controller/MemberRestControllerTest.java
@@ -1,0 +1,126 @@
+package com.fc.shimpyo_be.domain.member.unit.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.shimpyo_be.domain.member.dto.request.CheckPasswordRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.request.UpdateMemberRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.CheckPasswordResponseDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class MemberRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    WebApplicationContext context;
+
+    @MockBean
+    MemberService memberService;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(this.context)
+            .apply(springSecurity())
+            .build();
+    }
+
+    @Nested
+    @DisplayName("updateMember()은")
+    class Context_updateMember {
+
+        @Test
+        @DisplayName("회원 정보를 수정할 수 있다.")
+        @WithMockUser(roles = "USER")
+        void _willSuccess() throws Exception {
+            // given
+            UpdateMemberRequestDto request = UpdateMemberRequestDto.builder()
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .build();
+            MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+                .memberId(1L)
+                .email("test@mail.com")
+                .name("test")
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .build();
+
+            given(memberService.updateMember(any(UpdateMemberRequestDto.class))).willReturn(
+                memberResponseDto);
+
+            // when then
+            mockMvc.perform(patch("/api/members")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").isNumber())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.memberId").isNumber())
+                .andExpect(jsonPath("$.data.email").isString())
+                .andExpect(jsonPath("$.data.name").isString())
+                .andExpect(jsonPath("$.data.photoUrl").isString())
+                .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("checkPassword()은")
+    class Context_checkPassword {
+
+        @Test
+        @DisplayName("비밀번호가 일치하는지 확인할 수 있다.")
+        @WithMockUser(roles = "USER")
+        void _willSuccess() throws Exception {
+            // given
+            CheckPasswordRequestDto request = CheckPasswordRequestDto.builder()
+                .password("qwer1234$$")
+                .build();
+            CheckPasswordResponseDto checkPasswordResponseDto = CheckPasswordResponseDto.builder()
+                .isCorrectPassword(true)
+                .build();
+
+            given(memberService.checkPassword(any(CheckPasswordRequestDto.class))).willReturn(
+                checkPasswordResponseDto);
+
+            // when then
+            mockMvc.perform(post("/api/members")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").isNumber())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.correctPassword").isBoolean())
+                .andDo(print());
+        }
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/service/AuthServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -138,7 +139,7 @@ public class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 로그인을 할 수 없다.")
+        @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 회원 가입을 할 수 없다.")
         void unmatchedPassword_willFail() {
             // given
             SignUpRequestDto signUpRequestDto = SignUpRequestDto.builder()
@@ -149,7 +150,8 @@ public class AuthServiceTest {
                 .build();
 
             given(memberService.isExistsByEmail(any(String.class))).willReturn(false);
-
+            doThrow(new UnmatchedPasswordException()).when(memberService)
+                .checkMatchedPassword(any(String.class), any(String.class));
             // when
             Throwable exception = assertThrows(UnmatchedPasswordException.class, () -> {
                 authService.signUp(signUpRequestDto);
@@ -161,6 +163,7 @@ public class AuthServiceTest {
             verify(memberService, times(1)).isExistsByEmail(any(String.class));
             verify(memberService, never()).saveMember(any(Member.class));
         }
+
     }
 
     @Nested

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/service/MemberServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/service/MemberServiceTest.java
@@ -1,0 +1,170 @@
+package com.fc.shimpyo_be.domain.member.unit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fc.shimpyo_be.domain.member.dto.request.UpdateMemberRequestDto;
+import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
+import com.fc.shimpyo_be.domain.member.entity.Authority;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.exception.InvalidPasswordException;
+import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
+import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SecurityUtil securityUtil;
+
+    @Nested
+    @DisplayName("updateMember()는")
+    class Context_updateMember {
+
+        @Test
+        @DisplayName("회원 프로필 사진을 수정할 수 있다.")
+        void photoUrl_willSuccess() {
+            // given
+            UpdateMemberRequestDto updateMemberRequestDto = UpdateMemberRequestDto.builder()
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .build();
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl("")
+                .authority(Authority.ROLE_USER)
+                .build();
+
+            given(memberRepository.findById(any(Long.TYPE))).willReturn(Optional.of(member));
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+
+            // when
+            MemberResponseDto result = memberService.updateMember(updateMemberRequestDto);
+
+            assertNotNull(result);
+            assertThat(result).extracting("memberId", "email", "name", "photoUrl")
+                .containsExactly(1L, "test@mail.com", "test",
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI");
+
+            verify(memberRepository, times(1)).findById(any(Long.TYPE));
+        }
+
+        @Test
+        @DisplayName("비밀번호를 수정할 수 있다.")
+        void password_willSuccess() {
+            // given
+            UpdateMemberRequestDto updateMemberRequestDto = UpdateMemberRequestDto.builder()
+                .passwordConfirm("qwer1234!!")
+                .build();
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl("")
+                .authority(Authority.ROLE_USER)
+                .build();
+
+            given(memberRepository.findById(any(Long.TYPE))).willReturn(Optional.of(member));
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+
+            // when
+            MemberResponseDto result = memberService.updateMember(updateMemberRequestDto);
+
+            assertNotNull(result);
+            assertThat(result).extracting("memberId", "email", "name", "photoUrl")
+                .containsExactly(1L, "test@mail.com", "test", "");
+
+            verify(memberRepository, times(1)).findById(any(Long.TYPE));
+        }
+
+        @Test
+        @DisplayName("비밀번호가 양식에 맞지 않으면, 비밀번호를 수정할 수 없다.")
+        void InvalidPassword_willFail() {
+            // given
+            UpdateMemberRequestDto updateMemberRequestDto = UpdateMemberRequestDto.builder()
+                .password("qwer1234")
+                .passwordConfirm("qwer1234")
+                .build();
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl("")
+                .authority(Authority.ROLE_USER)
+                .build();
+
+            given(memberRepository.findById(any(Long.TYPE))).willReturn(Optional.of(member));
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+
+            // when
+            Throwable exception = assertThrows(InvalidPasswordException.class, () -> {
+                memberService.updateMember(updateMemberRequestDto);
+            });
+
+            // then
+            assertEquals("비밀번호 양식에 맞지 않습니다.", exception.getMessage());
+
+            verify(memberRepository, times(1)).findById(any(Long.TYPE));
+        }
+
+        @Test
+        @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면, 비밀번호를 수정할 수 없다.")
+        void UnmatchedPassword_willFail() {
+            // given
+            UpdateMemberRequestDto updateMemberRequestDto = UpdateMemberRequestDto.builder()
+                .password("qwer1234$$")
+                .passwordConfirm("qwer1234##")
+                .build();
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl("")
+                .authority(Authority.ROLE_USER)
+                .build();
+
+            given(memberRepository.findById(any(Long.TYPE))).willReturn(Optional.of(member));
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+
+            // when
+            Throwable exception = assertThrows(UnmatchedPasswordException.class, () -> {
+                memberService.updateMember(updateMemberRequestDto);
+            });
+
+            // then
+            assertEquals("비밀번호와 비밀번호 확인이 일치하지 않습니다.", exception.getMessage());
+
+            verify(memberRepository, times(1)).findById(any(Long.TYPE));
+        }
+    }
+}


### PR DESCRIPTION
### 💡 Motivation
- 회원 정보 수정 기능 구현이 필요합니다.
- 회원 API 문서화가 필요합니다. 

### 📌 Changes
- 회원 비밀번호 확인 기능 구현
- 회원 프로필 이미지 수정 기능 구현
- 회원 비밀번호 수정 기능 구현
- 구현한 기능 테스트 코드 작성
- REST Docs 테스트 코드 작성
- 회원 API adoc 파일 작성

### 🫱🏻‍🫲🏻 To Reviewers
- 코드 리뷰 부탁드립니다~

This close #9 #10 