### PR TITLE
fix: 비밀번호 확인 API 문서화를 위해 adoc 파일에 추가

### DIFF
--- a/src/docs/asciidoc/member/member-api.adoc
+++ b/src/docs/asciidoc/member/member-api.adoc
@@ -35,6 +35,21 @@ include::{snippets}/auth-rest-controller-docs-test/sign-in/request-fields.adoc[]
 include::{snippets}/auth-rest-controller-docs-test/sign-in/http-response.adoc[]
 include::{snippets}/auth-rest-controller-docs-test/sign-in/response-fields.adoc[]
 
+[[Check-Password]]
+== 비밀번호 확인
+
+비밀번호 확인 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/member-rest-controller-docs-test/check-password/http-request.adoc[]
+include::{snippets}/member-rest-controller-docs-test/check-password/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/member-rest-controller-docs-test/check-password/http-response.adoc[]
+include::{snippets}/member-rest-controller-docs-test/check-password/response-fields.adoc[]
+
 [[Update-Member]]
 == 회원 정보 수정
 

--- a/src/test/java/com/fc/shimpyo_be/domain/member/docs/MemberRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/docs/MemberRestControllerDocsTest.java
@@ -33,6 +33,39 @@ public class MemberRestControllerDocsTest extends RestDocsSupport {
         CheckPasswordRequestDto.class);
 
     @Test
+    @DisplayName("checkPassword()은 비밀번호가 일치하는지 확인할 수 있다.")
+    @WithMockUser(roles = "USER")
+    void checkPassword() throws Exception {
+        // given
+        CheckPasswordRequestDto request = CheckPasswordRequestDto.builder()
+            .password("qwer1234$$")
+            .build();
+        CheckPasswordResponseDto checkPasswordResponseDto = CheckPasswordResponseDto.builder()
+            .isCorrectPassword(true)
+            .build();
+
+        given(memberService.checkPassword(any(CheckPasswordRequestDto.class))).willReturn(
+            checkPasswordResponseDto);
+
+        // when then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/members")
+                .with(csrf())
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andDo(restDoc.document(
+                requestFields(
+                    fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                        .attributes(key("constraints").value(
+                            CheckPasswordDescriptions.descriptionsForProperty("password")))),
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.correctPassword").type(JsonFieldType.BOOLEAN)
+                        .description("회원 식별자")
+                ))
+            );
+    }
+
+    @Test
     @DisplayName("updateMember()은 회원 정보를 수정할 수 있다.")
     @WithMockUser(roles = "USER")
     void updateMember() throws Exception {
@@ -75,38 +108,4 @@ public class MemberRestControllerDocsTest extends RestDocsSupport {
                 ))
             );
     }
-
-    @Test
-    @DisplayName("checkPassword()은 비밀번호가 일치하는지 확인할 수 있다.")
-    @WithMockUser(roles = "USER")
-    void _willSuccess() throws Exception {
-        // given
-        CheckPasswordRequestDto request = CheckPasswordRequestDto.builder()
-            .password("qwer1234$$")
-            .build();
-        CheckPasswordResponseDto checkPasswordResponseDto = CheckPasswordResponseDto.builder()
-            .isCorrectPassword(true)
-            .build();
-
-        given(memberService.checkPassword(any(CheckPasswordRequestDto.class))).willReturn(
-            checkPasswordResponseDto);
-
-        // when then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/members")
-                .with(csrf())
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andDo(restDoc.document(
-                requestFields(
-                    fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
-                        .attributes(key("constraints").value(
-                            CheckPasswordDescriptions.descriptionsForProperty("password")))),
-                responseFields(responseCommon()).and(
-                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
-                    fieldWithPath("data.correctPassword").type(JsonFieldType.BOOLEAN)
-                        .description("회원 식별자")
-                ))
-            );
-    }
-
 }


### PR DESCRIPTION
### 💡 Motivation
- 비밀번호 확인 API가 adoc 파일에서 누락되었습니다. 

### 📌 Changes
- 회원 비밀번호 확인 REST Docs 테스트 메서드 명 수정
- 회원 비밀번호 확인 API를 adoc 파일에 추가

This close #13 