### PR TITLE
fix: build action 사용 (cd workflow 파일 내)

### DIFF
--- a/.github/workflows/shimpyoDeploy.yml
+++ b/.github/workflows/shimpyoDeploy.yml
@@ -46,7 +46,11 @@ jobs:
     - name: Build with Gradle1
       run: |
         chmod +x ./gradlew
-        ./gradlew clean build -x test
+
+    - name: Build with Gradle2
+      uses: gradle/gradle-build-action@v2.6.0
+      with:
+        arguments: build
         
 
     - name: Docker build & push to docker repo


### PR DESCRIPTION
동기

- build 명령어 그냥 사용 시, snippet 폴더를 인식 못해서 build action 사용 

수정사항

- build action 사용 