### PR TITLE
refactor: 회원 Error Code 도입 및 Exception 핸들링 변경

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/member/controller/AuthRestControllerAdvice.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/controller/AuthRestControllerAdvice.java
@@ -1,45 +1,8 @@
 package com.fc.shimpyo_be.domain.member.controller;
 
-import com.fc.shimpyo_be.domain.member.exception.AlreadyExistsMemberException;
-import com.fc.shimpyo_be.domain.member.exception.InvalidRefreshTokenException;
-import com.fc.shimpyo_be.domain.member.exception.LoggedOutException;
-import com.fc.shimpyo_be.domain.member.exception.MemberNotFoundException;
-import com.fc.shimpyo_be.domain.member.exception.UnmatchedMemberException;
-import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
-import com.fc.shimpyo_be.global.common.ResponseDto;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class AuthRestControllerAdvice {
 
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> alreadySignUpException(
-        AlreadyExistsMemberException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> InvalidRefreshTokenException(
-        InvalidRefreshTokenException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> loggedOutException(
-        LoggedOutException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> unmatchedMemberException(
-        UnmatchedMemberException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/controller/MemberRestControllerAdvice.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/controller/MemberRestControllerAdvice.java
@@ -1,43 +1,8 @@
 package com.fc.shimpyo_be.domain.member.controller;
 
-import com.fc.shimpyo_be.domain.member.exception.InvalidPasswordException;
-import com.fc.shimpyo_be.domain.member.exception.MemberNotFoundException;
-import com.fc.shimpyo_be.domain.member.exception.UnmatchedPasswordException;
-import com.fc.shimpyo_be.domain.member.exception.WrongPasswordException;
-import com.fc.shimpyo_be.global.common.ResponseDto;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class MemberRestControllerAdvice {
 
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> MemberNotFoundException(
-        MemberNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(ResponseDto.res(HttpStatus.NOT_FOUND, e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> wrongPasswordException(
-        WrongPasswordException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> invalidPasswordException(
-        InvalidPasswordException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ResponseDto<Void>> unmatchedPasswordException(
-        UnmatchedPasswordException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDto.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/AlreadyExistsMemberException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/AlreadyExistsMemberException.java
@@ -1,8 +1,11 @@
 package com.fc.shimpyo_be.domain.member.exception;
 
-public class AlreadyExistsMemberException extends RuntimeException{
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
 
-    public AlreadyExistsMemberException(){
-        super("이미 가입된 회원 입니다.");
+public class AlreadyExistsMemberException extends ApplicationException {
+
+    public AlreadyExistsMemberException() {
+        super(ErrorCode.ALREADY_EXISTS_MEMBER);
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/InvalidPasswordException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/InvalidPasswordException.java
@@ -1,8 +1,11 @@
 package com.fc.shimpyo_be.domain.member.exception;
 
-public class InvalidPasswordException extends RuntimeException{
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+
+public class InvalidPasswordException extends ApplicationException {
 
     public InvalidPasswordException() {
-        super("비밀번호 양식에 맞지 않습니다.");
+        super(ErrorCode.INVALID_PASSWORD);
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/InvalidRefreshTokenException.java
@@ -1,8 +1,11 @@
 package com.fc.shimpyo_be.domain.member.exception;
 
-public class InvalidRefreshTokenException extends RuntimeException{
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
 
-    public InvalidRefreshTokenException(){
-        super("Refresh Token 이 유효하지 않습니다.");
+public class InvalidRefreshTokenException extends ApplicationException {
+
+    public InvalidRefreshTokenException() {
+        super(ErrorCode.INVALID_REFRESH_TOKEN);
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/LoggedOutException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/LoggedOutException.java
@@ -1,8 +1,11 @@
 package com.fc.shimpyo_be.domain.member.exception;
 
-public class LoggedOutException extends RuntimeException{
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
 
-    public LoggedOutException(){
-        super("로그아웃 된 회원 입니다.");
+public class LoggedOutException extends ApplicationException {
+
+    public LoggedOutException() {
+        super(ErrorCode.LOGGED_OUT);
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/MemberNotFoundException.java
@@ -1,8 +1,11 @@
 package com.fc.shimpyo_be.domain.member.exception;
 
-public class MemberNotFoundException extends RuntimeException{
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
 
-    public MemberNotFoundException(){
-        super("회원 정보를 찾을 수 없습니다.");
+public class MemberNotFoundException extends ApplicationException {
+
+    public MemberNotFoundException() {
+        super(ErrorCode.MEMBER_NOT_FOUND);
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/UnmatchedMemberException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/UnmatchedMemberException.java
@@ -1,8 +1,11 @@
 package com.fc.shimpyo_be.domain.member.exception;
 
-public class UnmatchedMemberException extends RuntimeException{
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
 
-    public UnmatchedMemberException(){
-        super("토큰의 회원 정보가 일치하지 않습니다.");
+public class UnmatchedMemberException extends ApplicationException {
+
+    public UnmatchedMemberException() {
+        super(ErrorCode.UNMATCHED_MEMBER);
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/UnmatchedPasswordException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/UnmatchedPasswordException.java
@@ -1,8 +1,11 @@
 package com.fc.shimpyo_be.domain.member.exception;
 
-public class UnmatchedPasswordException extends RuntimeException{
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
 
-    public UnmatchedPasswordException(){
-        super("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+public class UnmatchedPasswordException extends ApplicationException {
+
+    public UnmatchedPasswordException() {
+        super(ErrorCode.UNMATCHED_PASSWORD);
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/member/exception/WrongPasswordException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/member/exception/WrongPasswordException.java
@@ -1,8 +1,11 @@
 package com.fc.shimpyo_be.domain.member.exception;
 
-public class WrongPasswordException extends RuntimeException{
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
 
-    public WrongPasswordException(){
-        super("비밀번호가 틀렸습니다.");
+public class WrongPasswordException extends ApplicationException {
+
+    public WrongPasswordException() {
+        super(ErrorCode.WRONG_PASSWORD);
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
@@ -7,6 +7,16 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
+    // 회원
+    ALREADY_EXISTS_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 회원 입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호 양식에 맞지 않습니다."),
+    UNMATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token 이 유효하지 않습니다."),
+    LOGGED_OUT(HttpStatus.UNAUTHORIZED, "로그아웃 된 회원 입니다."),
+    UNMATCHED_MEMBER(HttpStatus.UNAUTHORIZED, "토큰의 회원 정보가 일치하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
+
     // 상품
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정보를 찾을 수 없습니다."),
     ROOM_NOT_RESERVE(HttpStatus.FORBIDDEN, "예약 불가능한 방입니다."),


### PR DESCRIPTION
### 💡 Motivation
- 회원 도메인에서 발생하는 에러를 Error Code에서 관리하도록 한다. 
- FE 분들의 요청에 따라 인증/인가에 관한 에러 코드를 수정한다. 
- Excpetion 핸들링은 Global Controller Advice로 양도하도록 한다. 

### 📌 Changes
- 회원 Error도 ErrorCode에서 관리
- 토큰에 해당하는 회원이 없는 경우 UNAUTHORIZED 에러 코드 응
- 리프레시 토큰이 유효하지 않은 경우 UNAUTHORIZED 에러 코드 응답
- 로그아웃 한 회원의 리프레시 토큰으로 토큰 재발급을 요청하는 경우 UNAUTHORIZED 에러 코드 응답
- 비밀번호 확인에 실패한 경우 UNAUTHORIZED 에러 코드 응답
- 회원 API에서 발생한 Exception 을 Global Controller Advice에서 핸들링

### 🫱🏻‍🫲🏻 To Reviewers
- 리뷰 부탁드립니다! 😉

This close #26 