### PR TITLE
CORS allow origin 버그 해결

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/global/config/CorsConfig.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("*");
+        config.addAllowedOriginPattern("*");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         source.registerCorsConfiguration("/api/**", config);


### PR DESCRIPTION
### 💡 Motivation
- CORS 설정 시 allowCredential 이 true 라면 “Access-Control-Allow-Origin” 응답 헤더를 설정 할 수 없기 때문에 에러가 발생
- 따라서 특정 주소만 허락하거나, addAllOrigin("\*") 대신 .addAllOriginPatterns("\*")를 사용해야 함
- 개발 단계이기 때문에 일단 .addAllOriginPatterns("\*")를 사용하기로 함

### 📌 Changes
- addAllOrigin("\*") 대신 .addAllOriginPatterns("\*")를 사용

### 🫱🏻‍🫲🏻 To Reviewers
- 급한 사항이니 빠른 approve 부탁드려요~~!

this close #35 