### PR TITLE
feat: 예약 가능 유효성 검증 및 선점 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.24.3'
+
     // Spring REST Docs
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/controller/ReservationRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/controller/ReservationRestController.java
@@ -1,0 +1,38 @@
+package com.fc.shimpyo_be.domain.reservation.controller;
+
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
+import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
+import com.fc.shimpyo_be.global.common.ResponseDto;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/reservations")
+@RestController
+public class ReservationRestController {
+
+    private final PreoccupyRoomsLockFacade preoccupyRoomsLockFacade;
+    private final SecurityUtil securityUtil;
+
+    @PostMapping("/preoccupy")
+    public ResponseEntity<ResponseDto<Void>> checkAvailableAndPreoccupy(@Valid @RequestBody PreoccupyRoomsRequestDto request) {
+        log.info("[api][POST] /api/reservations/preoccupy");
+
+        preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(securityUtil.getCurrentMemberId(), request);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(
+                ResponseDto.res(HttpStatus.OK, "예약 가능 유효성 검사와 객실 선점이 정상적으로 완료되었습니다.")
+            );
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/CheckAvailableRoomsResultDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/CheckAvailableRoomsResultDto.java
@@ -1,0 +1,11 @@
+package com.fc.shimpyo_be.domain.reservation.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record CheckAvailableRoomsResultDto(
+    boolean isAvailable,
+    List<Long> unavailableIds,
+    Map<Long, Map<String, String>> recordMap
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/PreoccupyRoomItemRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/PreoccupyRoomItemRequestDto.java
@@ -1,0 +1,14 @@
+package com.fc.shimpyo_be.domain.reservation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record PreoccupyRoomItemRequestDto(
+    @NotNull
+    Long roomId,
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 날짜 형식이 아닙니다.(yyyy-MM-dd 형식으로 입력하세요.)")
+    String startDate,
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 날짜 형식이 아닙니다.(yyyy-MM-dd 형식으로 입력하세요.)")
+    String endDate
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/PreoccupyRoomsRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/PreoccupyRoomsRequestDto.java
@@ -1,0 +1,14 @@
+package com.fc.shimpyo_be.domain.reservation.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record PreoccupyRoomsRequestDto(
+
+    @Valid
+    @Size(min = 1, max = 3, message = "최소 1개, 최대 3개의 객실 예약이 가능합니다.")
+    List<PreoccupyRoomItemRequestDto> rooms
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/PreoccupyRoomsResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/PreoccupyRoomsResponseDto.java
@@ -1,0 +1,9 @@
+package com.fc.shimpyo_be.domain.reservation.dto.response;
+
+import java.util.List;
+
+public record PreoccupyRoomsResponseDto(
+    boolean isAvailable,
+    List<Long> unavailableIds
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/entity/PayMethod.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/entity/PayMethod.java
@@ -3,6 +3,8 @@ package com.fc.shimpyo_be.domain.reservation.entity;
 public enum PayMethod {
 
     CREDIT_CARD,
-    CASH,
-    ACCOUNT_TRANSFER
+    KAKAO_PAY,
+    TOSS_PAY,
+    NAVER_PAY,
+    PAYPAL
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/RedissonLockFailException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/RedissonLockFailException.java
@@ -1,0 +1,11 @@
+package com.fc.shimpyo_be.domain.reservation.exception;
+
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+
+public class RedissonLockFailException extends ApplicationException {
+
+    public RedissonLockFailException() {
+        super(ErrorCode.LOCK_FAIL);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/ReservationRestControllerAdvice.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/ReservationRestControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.fc.shimpyo_be.domain.reservation.exception;
+
+import com.fc.shimpyo_be.domain.reservation.dto.response.PreoccupyRoomsResponseDto;
+import com.fc.shimpyo_be.global.common.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ReservationRestControllerAdvice {
+
+    @ExceptionHandler(UnavailableRoomsException.class)
+    public ResponseEntity<ResponseDto<PreoccupyRoomsResponseDto>> unavailableRoomsException(
+        UnavailableRoomsException e) {
+        return ResponseEntity
+            .status(e.getErrorCode().getHttpStatus())
+            .body(ResponseDto.res(e.getErrorCode().getHttpStatus(), e.getData(), e.getMessage()));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/UnavailableRoomsException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/UnavailableRoomsException.java
@@ -1,0 +1,23 @@
+package com.fc.shimpyo_be.domain.reservation.exception;
+
+import com.fc.shimpyo_be.domain.reservation.dto.response.PreoccupyRoomsResponseDto;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UnavailableRoomsException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private PreoccupyRoomsResponseDto data;
+
+    public UnavailableRoomsException() {
+        super(ErrorCode.UNAVAILABLE_ROOMS.getSimpleMessage());
+        this.errorCode = ErrorCode.UNAVAILABLE_ROOMS;
+    }
+
+    public UnavailableRoomsException(PreoccupyRoomsResponseDto data) {
+        super(ErrorCode.UNAVAILABLE_ROOMS.getSimpleMessage());
+        this.errorCode = ErrorCode.UNAVAILABLE_ROOMS;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/facade/PreoccupyRoomsLockFacade.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/facade/PreoccupyRoomsLockFacade.java
@@ -1,0 +1,57 @@
+package com.fc.shimpyo_be.domain.reservation.facade;
+
+import com.fc.shimpyo_be.domain.reservation.dto.CheckAvailableRoomsResultDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.PreoccupyRoomsResponseDto;
+import com.fc.shimpyo_be.domain.reservation.exception.RedissonLockFailException;
+import com.fc.shimpyo_be.domain.reservation.exception.UnavailableRoomsException;
+import com.fc.shimpyo_be.domain.reservation.service.PreoccupyRoomsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PreoccupyRoomsLockFacade {
+
+    private final RedissonClient redissonClient;
+    private final PreoccupyRoomsService preoccupyRoomsService;
+
+
+    public void checkAvailableAndPreoccupy(Long memberId, PreoccupyRoomsRequestDto request) {
+        RLock lock = redissonClient.getLock("check-preoccupy");
+        String currentWorker = Thread.currentThread().getName();
+
+        try {
+            boolean isLocked = lock.tryLock(2, 4, TimeUnit.SECONDS);
+
+            if(!isLocked) {
+                log.error("[{}] 체크 및 선점 lock 획득 실패", currentWorker);
+                throw new RedissonLockFailException();
+            }
+
+            CheckAvailableRoomsResultDto resultDto = preoccupyRoomsService.checkAvailable(memberId, request);
+            if(!resultDto.isAvailable()) {
+                log.info("[{}][check available rooms result] isAvailable = {}, unavailableIds = {}", currentWorker, false, resultDto.unavailableIds());
+                throw new UnavailableRoomsException(
+                    new PreoccupyRoomsResponseDto(false, resultDto.unavailableIds())
+                );
+            }
+
+            log.info("[{}][check available rooms result] isAvailable = {}, unavailableIds = {}", currentWorker, true, resultDto.unavailableIds());
+            preoccupyRoomsService.preoccupy(request, resultDto.recordMap());
+
+        } catch (Exception exception) {
+            log.error("exception : {}, message : {}", exception.getClass().getSimpleName(), exception.getMessage());
+            throw new RedissonLockFailException();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
@@ -1,0 +1,82 @@
+package com.fc.shimpyo_be.domain.reservation.service;
+
+import com.fc.shimpyo_be.domain.reservation.dto.CheckAvailableRoomsResultDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomItemRequestDto;
+import com.fc.shimpyo_be.global.util.DateUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PreoccupyRoomsService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String REDIS_KEY_FORMAT = "roomId:%d:%s";
+
+    public CheckAvailableRoomsResultDto checkAvailable(Long memberId, PreoccupyRoomsRequestDto request) {
+        ValueOperations<String, Object> opsForValue = redisTemplate.opsForValue();
+
+        boolean isAvailable = true;
+        List<Long> unavailableIds = new LinkedList<>();
+        Map<Long, Map<String, String>> recordMap = new HashMap<>();
+        String memberIdValue = String.valueOf(memberId);
+
+        for (PreoccupyRoomItemRequestDto room : request.rooms()) {
+
+            LocalDate targetDate = DateUtil.toLocalDate(room.startDate());
+            LocalDate endDate = DateUtil.toLocalDate(room.endDate());
+
+            while(targetDate.isBefore(endDate)) {
+
+                String key = String.format(REDIS_KEY_FORMAT, room.roomId(), targetDate);
+                Object value = opsForValue.get(key);
+
+                log.info("roomId: {}, targetDate: {}, value: {}", room.roomId(), targetDate, value);
+                if(Objects.nonNull(value)) {
+                    isAvailable = false;
+                    unavailableIds.add(room.roomId());
+                    break;
+                }
+
+                recordMap
+                    .computeIfAbsent(room.roomId(), k -> new LinkedHashMap<>())
+                    .put(key, memberIdValue);
+
+                targetDate = targetDate.plusDays(1);
+            }
+        }
+
+        return new CheckAvailableRoomsResultDto(isAvailable, unavailableIds, recordMap);
+    }
+
+    public void preoccupy(PreoccupyRoomsRequestDto request, Map<Long, Map<String, String>> preoccupyMap) {
+        ValueOperations<String, Object> opsForValue = redisTemplate.opsForValue();
+
+        for (PreoccupyRoomItemRequestDto room : request.rooms()) {
+            Map<String, String> map = preoccupyMap.get(room.roomId());
+            opsForValue.multiSet(map);
+
+            Date expireDate = convertLocalDateToDate(DateUtil.toLocalDate(room.endDate()).minusDays(1));
+            for (String key : map.keySet()) {
+                redisTemplate.expireAt(key, expireDate);
+            }
+        }
+    }
+
+    private Date convertLocalDateToDate(LocalDate localDate) {
+        return Date.from(
+            localDate
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+        );
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/room/entity/Room.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/room/entity/Room.java
@@ -42,9 +42,17 @@ public class Room {
     private int price;
 
     @Builder
-    public Room(Long id, Product product, String name, String description, int standard,
+    public Room(
+        Long id,
+        Product product,
+        String name,
+        String description,
+        int standard,
         int capacity,
-        int price, LocalTime checkIn, LocalTime checkOut) {
+        int price,
+        LocalTime checkIn,
+        LocalTime checkOut
+    ) {
         this.id = id;
         this.product = product;
         this.name = name;

--- a/src/main/java/com/fc/shimpyo_be/global/config/RedissonConfig.java
+++ b/src/main/java/com/fc/shimpyo_be/global/config/RedissonConfig.java
@@ -1,0 +1,29 @@
+package com.fc.shimpyo_be.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+            .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
@@ -22,6 +22,10 @@ public enum ErrorCode {
     ROOM_NOT_RESERVE(HttpStatus.FORBIDDEN, "예약 불가능한 방입니다."),
     ROON_NOT_FOUND(HttpStatus.NOT_FOUND,"방 정보를 찾을 수 없습니다."),
 
+    // 예약
+    UNAVAILABLE_ROOMS(HttpStatus.BAD_REQUEST, "예약 불가능한 방이 존재합니다."),
+    LOCK_FAIL(HttpStatus.BAD_REQUEST, "요청 완료에 실패했습니다. 재시도가 필요합니다."),
+
     // Open API
     HTTP_CLIENT_CONNECTION_ERROR(HttpStatus.UNAUTHORIZED, "외부 API 연결에 실패했습니다.");
 

--- a/src/main/java/com/fc/shimpyo_be/global/util/DateUtil.java
+++ b/src/main/java/com/fc/shimpyo_be/global/util/DateUtil.java
@@ -5,15 +5,15 @@ import java.time.format.DateTimeFormatter;
 
 public class DateUtil {
 
-    public final static String LOCAL_DATE_TIME_PATTERN = "yyyy-MM-dd";
+    public final static String LOCAL_DATE_PATTERN = "yyyy-MM-dd";
 
     public final static String LOCAL_DATE_REGEX_PATTERN = "\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])";
 
     public static String toString(LocalDate dateObject) {
-        return dateObject.format(DateTimeFormatter.ofPattern(LOCAL_DATE_TIME_PATTERN));
+        return dateObject.format(DateTimeFormatter.ofPattern(LOCAL_DATE_PATTERN));
     }
 
     public static LocalDate toLocalDate(String dateString) {
-        return LocalDate.parse(dateString, DateTimeFormatter.ofPattern(LOCAL_DATE_TIME_PATTERN));
+        return LocalDate.parse(dateString, DateTimeFormatter.ofPattern(LOCAL_DATE_PATTERN));
     }
 }

--- a/src/test/java/com/fc/shimpyo_be/ShimpyoBeApplicationTests.java
+++ b/src/test/java/com/fc/shimpyo_be/ShimpyoBeApplicationTests.java
@@ -1,10 +1,11 @@
 package com.fc.shimpyo_be;
 
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ShimpyoBeApplicationTests {
+class ShimpyoBeApplicationTests extends AbstractContainersSupport {
     @Test
     void contextLoads() {
     }

--- a/src/test/java/com/fc/shimpyo_be/config/AbstractContainersSupport.java
+++ b/src/test/java/com/fc/shimpyo_be/config/AbstractContainersSupport.java
@@ -1,11 +1,9 @@
 package com.fc.shimpyo_be.config;
 
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 
-@SpringBootTest
 public abstract class AbstractContainersSupport {
 
     static final String REDIS_IMAGE = "redis:6-alpine";

--- a/src/test/java/com/fc/shimpyo_be/config/RestDocsSupport.java
+++ b/src/test/java/com/fc/shimpyo_be/config/RestDocsSupport.java
@@ -26,7 +26,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @SpringBootTest
 @ExtendWith({RestDocumentationExtension.class})
 @Import(RestDocsConfig.class)
-public abstract class RestDocsSupport {
+public abstract class RestDocsSupport extends AbstractContainersSupport {
 
     @Autowired
     protected ObjectMapper objectMapper;

--- a/src/test/java/com/fc/shimpyo_be/domain/member/docs/MemberRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/docs/MemberRestControllerDocsTest.java
@@ -1,16 +1,5 @@
 package com.fc.shimpyo_be.domain.member.docs;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.snippet.Attributes.key;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-
 import com.fc.shimpyo_be.config.RestDocsSupport;
 import com.fc.shimpyo_be.domain.member.dto.request.CheckPasswordRequestDto;
 import com.fc.shimpyo_be.domain.member.dto.request.UpdateMemberRequestDto;
@@ -24,6 +13,14 @@ import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 
 public class MemberRestControllerDocsTest extends RestDocsSupport {
 

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/controller/AuthRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/controller/AuthRestControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
 import com.fc.shimpyo_be.domain.member.dto.request.RefreshRequestDto;
 import com.fc.shimpyo_be.domain.member.dto.request.SignInRequestDto;
 import com.fc.shimpyo_be.domain.member.dto.request.SignUpRequestDto;
@@ -33,7 +34,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class AuthRestControllerTest {
+public class AuthRestControllerTest extends AbstractContainersSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/fc/shimpyo_be/domain/member/unit/controller/MemberRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/member/unit/controller/MemberRestControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
 import com.fc.shimpyo_be.domain.member.dto.request.CheckPasswordRequestDto;
 import com.fc.shimpyo_be.domain.member.dto.request.UpdateMemberRequestDto;
 import com.fc.shimpyo_be.domain.member.dto.response.MemberResponseDto;
@@ -32,7 +33,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class MemberRestControllerTest {
+public class MemberRestControllerTest extends AbstractContainersSupport {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/docs/ReservationRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/docs/ReservationRestControllerDocsTest.java
@@ -1,0 +1,97 @@
+package com.fc.shimpyo_be.domain.reservation.docs;
+
+import com.fc.shimpyo_be.config.RestDocsSupport;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomItemRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.PreoccupyRoomsResponseDto;
+import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ReservationRestControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private PreoccupyRoomsLockFacade preoccupyRoomsLockFacade;
+
+    @MockBean
+    private SecurityUtil securityUtil;
+
+    private final ConstraintDescriptions preoccupyRoomsDescriptions
+        = new ConstraintDescriptions(PreoccupyRoomsRequestDto.class);
+
+    private final ConstraintDescriptions preoccupyRoomItemDescriptions
+        = new ConstraintDescriptions(PreoccupyRoomItemRequestDto.class);
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("checkAvailableAndPreoccupy()는 객실 예약이 가능한지 검증하고, 가능한 경우 객실을 선점한다.")
+    @Test
+    void checkAvailableAndPreoccupy_test() throws Exception {
+        // given
+        String requestUrl = "/api/reservations/preoccupy";
+
+        PreoccupyRoomsRequestDto requestDto
+            = new PreoccupyRoomsRequestDto(
+            List.of(
+                new PreoccupyRoomItemRequestDto(1L, "2023-12-23", "2023-12-25"),
+                new PreoccupyRoomItemRequestDto(2L, "2023-11-11", "2023-11-14")
+            )
+        );
+
+        PreoccupyRoomsResponseDto responseDto
+            = new PreoccupyRoomsResponseDto(true, new ArrayList<>());
+
+        given(securityUtil.getCurrentMemberId())
+            .willReturn(1L);
+        willDoNothing()
+            .given(preoccupyRoomsLockFacade)
+            .checkAvailableAndPreoccupy(1L, requestDto);
+
+        // when
+        mockMvc.perform(post(requestUrl)
+                .content(objectMapper.writeValueAsString(requestDto))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(restDoc.document(
+                    requestFields(
+                        fieldWithPath("rooms").type(JsonFieldType.ARRAY).description("예약할 객실 리스트")
+                            .attributes(key("constraints").value(
+                                preoccupyRoomsDescriptions.descriptionsForProperty("rooms"))),
+                        fieldWithPath("rooms[].roomId").type(JsonFieldType.NUMBER).description("예약할 객실 식별자")
+                            .attributes(key("constraints").value(
+                                preoccupyRoomItemDescriptions.descriptionsForProperty("roomId"))),
+                        fieldWithPath("rooms[].startDate").type(JsonFieldType.STRING).description("숙박 시작일")
+                            .attributes(key("constraints").value(
+                                preoccupyRoomItemDescriptions.descriptionsForProperty("startDate"))),
+                        fieldWithPath("rooms[].endDate").type(JsonFieldType.STRING).description("숙박 마지막일")
+                            .attributes(key("constraints").value(
+                                preoccupyRoomItemDescriptions.descriptionsForProperty("endDate")))
+                    ),
+                    responseFields(responseCommon()).and(
+                        fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터")
+                    )
+                )
+            );
+
+        verify(preoccupyRoomsLockFacade, times(1)).checkAvailableAndPreoccupy(anyLong(), any(PreoccupyRoomsRequestDto.class));
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/controller/ReservationRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/controller/ReservationRestControllerTest.java
@@ -1,0 +1,160 @@
+package com.fc.shimpyo_be.domain.reservation.unit.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomItemRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.PreoccupyRoomsResponseDto;
+import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+public class ReservationRestControllerTest extends AbstractContainersSupport {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PreoccupyRoomsLockFacade preoccupyRoomsLockFacade;
+
+    @MockBean
+    private SecurityUtil securityUtil;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp(@Autowired WebApplicationContext applicationContext) {
+        this.mockMvc = MockMvcBuilders
+            .webAppContextSetup(applicationContext)
+            .apply(springSecurity())
+            .alwaysDo(print())
+            .build();
+    }
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("[api][POST][정상] 예약 유효성 검증 및 예약 선점 API")
+    @Test
+    void checkAvailableAndPreoccupy_test() throws Exception {
+        // given
+        String requestUrl = "/api/reservations/preoccupy";
+
+        PreoccupyRoomsRequestDto requestDto
+            = new PreoccupyRoomsRequestDto(
+                List.of(
+                    new PreoccupyRoomItemRequestDto(1L, "2023-12-23", "2023-12-25"),
+                    new PreoccupyRoomItemRequestDto(2L, "2023-11-11", "2023-11-14")
+                )
+        );
+
+        PreoccupyRoomsResponseDto responseDto
+            = new PreoccupyRoomsResponseDto(true, new ArrayList<>());
+
+        given(securityUtil.getCurrentMemberId())
+            .willReturn(1L);
+        willDoNothing()
+            .given(preoccupyRoomsLockFacade)
+            .checkAvailableAndPreoccupy(1L, requestDto);
+
+        // when & then
+        mockMvc.perform(
+            post(requestUrl)
+                .content(objectMapper.writeValueAsString(requestDto))
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("[api][POST][에러] 예약 유효성 검증 및 예약 선점 API - 예약 리스트 최대 갯수 초과")
+    @Test
+    void checkAvailableAndPreoccupy_size_validation_error_test() throws Exception {
+        // given
+        String requestUrl = "/api/reservations/preoccupy";
+
+        PreoccupyRoomsRequestDto requestDto
+            = new PreoccupyRoomsRequestDto(
+            List.of(
+                new PreoccupyRoomItemRequestDto(1L, "2023-12-23", "2023-12-25"),
+                new PreoccupyRoomItemRequestDto(2L, "2023-11-11", "2023-11-14"),
+                new PreoccupyRoomItemRequestDto(3L, "2023-11-11", "2023-11-14"),
+                new PreoccupyRoomItemRequestDto(4L, "2023-11-11", "2023-11-14")
+            )
+        );
+
+        PreoccupyRoomsResponseDto responseDto
+            = new PreoccupyRoomsResponseDto(true, new ArrayList<>());
+
+        given(securityUtil.getCurrentMemberId())
+            .willReturn(1L);
+        willDoNothing()
+            .given(preoccupyRoomsLockFacade)
+            .checkAvailableAndPreoccupy(1L, requestDto);
+
+        // when & then
+        mockMvc.perform(
+                post(requestUrl)
+                    .content(objectMapper.writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", is(400)));
+    }
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("[api][POST][에러] 예약 유효성 검증 및 예약 선점 API - 스트링 날짜 유효성 에러")
+    @Test
+    void checkAvailableAndPreoccupy_localdate_validation_error_test() throws Exception {
+        // given
+        String requestUrl = "/api/reservations/preoccupy";
+
+        PreoccupyRoomsRequestDto requestDto
+            = new PreoccupyRoomsRequestDto(
+            List.of(
+                new PreoccupyRoomItemRequestDto(1L, "202-12-23", "2023-12-25"),
+                new PreoccupyRoomItemRequestDto(2L, "2023-11-11", "2023-11-14"),
+                new PreoccupyRoomItemRequestDto(3L, "2023-11-11", "2023-11-14")
+            )
+        );
+
+        PreoccupyRoomsResponseDto responseDto
+            = new PreoccupyRoomsResponseDto(true, new ArrayList<>());
+
+        given(securityUtil.getCurrentMemberId())
+            .willReturn(1L);
+        willDoNothing()
+            .given(preoccupyRoomsLockFacade)
+            .checkAvailableAndPreoccupy(1L, requestDto);
+
+        // when & then
+        mockMvc.perform(
+                post(requestUrl)
+                    .content(objectMapper.writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", is(400)));
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/facade/PreoccupyRoomsLockFacadeTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/facade/PreoccupyRoomsLockFacadeTest.java
@@ -1,0 +1,133 @@
+package com.fc.shimpyo_be.domain.reservation.unit.facade;
+
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomItemRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
+import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.StopWatch;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@SpringBootTest
+public class PreoccupyRoomsLockFacadeTest extends AbstractContainersSupport {
+
+    @Autowired
+    private PreoccupyRoomsLockFacade preoccupyRoomsLockFacade;
+
+    private static final ThreadLocal<StopWatch> threadLocalStopWatch = ThreadLocal.withInitial(StopWatch::new);
+
+    @Test
+    void checkAvailable() throws InterruptedException {
+        int poolSize = 2;
+        int threadSize = 5;
+
+        ExecutorService executors = Executors.newFixedThreadPool(poolSize);
+        CountDownLatch latch = new CountDownLatch(threadSize);
+
+        PreoccupyRoomsRequestDto request1 = new PreoccupyRoomsRequestDto(List.of(
+            new PreoccupyRoomItemRequestDto(1L, "2024-03-05", "2024-03-08"),
+            new PreoccupyRoomItemRequestDto(2L, "2024-04-05", "2024-04-09")
+        ));
+        PreoccupyRoomsRequestDto request2 = new PreoccupyRoomsRequestDto(List.of(
+            new PreoccupyRoomItemRequestDto(1L, "2024-03-06", "2024-03-09"),
+            new PreoccupyRoomItemRequestDto(2L, "2024-04-04", "2024-04-06")
+        ));
+        PreoccupyRoomsRequestDto request3 = new PreoccupyRoomsRequestDto(List.of(
+            new PreoccupyRoomItemRequestDto(1L, "2024-02-10", "2024-02-15"),
+            new PreoccupyRoomItemRequestDto(3L, "2024-04-05", "2024-04-09")
+        ));
+        PreoccupyRoomsRequestDto request4 = new PreoccupyRoomsRequestDto(List.of(
+            new PreoccupyRoomItemRequestDto(3L, "2024-04-04", "2024-04-08")
+        ));
+        PreoccupyRoomsRequestDto request5 = new PreoccupyRoomsRequestDto(List.of(
+            new PreoccupyRoomItemRequestDto(5L, "2024-03-05", "2024-03-08"),
+            new PreoccupyRoomItemRequestDto(6L, "2024-04-05", "2024-04-09"),
+            new PreoccupyRoomItemRequestDto(7L, "2024-04-05", "2024-04-09")
+        ));
+
+        executors.submit(() -> {
+            StopWatch stopWatch = threadLocalStopWatch.get();
+            try {
+                stopWatch.start();
+                preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(1L, request1);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            } finally {
+                stopWatch.stop();
+                log.info("{} ::: {} ms", "request1", stopWatch.getTotalTimeMillis());
+                threadLocalStopWatch.remove();
+                latch.countDown();
+            }
+        });
+
+        executors.submit(() -> {
+            StopWatch stopWatch = threadLocalStopWatch.get();
+            try {
+                stopWatch.start();
+                preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(2L, request2);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            } finally {
+                stopWatch.stop();
+                log.info("{} ::: {} ms", "request2", stopWatch.getTotalTimeMillis());
+                threadLocalStopWatch.remove();
+                latch.countDown();
+            }
+        });
+
+        executors.submit(() -> {
+            StopWatch stopWatch = threadLocalStopWatch.get();
+            try {
+                stopWatch.start();
+                preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(3L, request3);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            } finally {
+                stopWatch.stop();
+                log.info("{} ::: {} ms", "request3", stopWatch.getTotalTimeMillis());
+                threadLocalStopWatch.remove();
+                latch.countDown();
+            }
+        });
+
+        executors.submit(() -> {
+            StopWatch stopWatch = threadLocalStopWatch.get();
+            try {
+                stopWatch.start();
+                preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(4L, request4);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            } finally {
+                stopWatch.stop();
+                log.info("{} ::: {} ms", "request4", stopWatch.getTotalTimeMillis());
+                threadLocalStopWatch.remove();
+                latch.countDown();
+            }
+        });
+
+        executors.submit(() -> {
+            StopWatch stopWatch = threadLocalStopWatch.get();
+            try {
+                stopWatch.start();
+                preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(5L, request5);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            } finally {
+                stopWatch.stop();
+                log.info("{} ::: {} ms", "request5", stopWatch.getTotalTimeMillis());
+                threadLocalStopWatch.remove();
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/star/unit/controller/StarRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/star/unit/controller/StarRestControllerTest.java
@@ -1,6 +1,7 @@
 package com.fc.shimpyo_be.domain.star.unit.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
 import com.fc.shimpyo_be.domain.star.dto.request.StarRegisterRequestDto;
 import com.fc.shimpyo_be.domain.star.dto.response.StarResponseDto;
 import com.fc.shimpyo_be.domain.star.service.StarService;
@@ -27,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-class StarRestControllerTest {
+class StarRestControllerTest extends AbstractContainersSupport {
 
     private MockMvc mockMvc;
 


### PR DESCRIPTION
### 💡 Motivation
- 예약이 가능한지 유효성 검사 후, 객실 예약을 선점하는 기능을 개발합니다.

### 📌 Changes
- Redisson 관련 설정 파일인 RedissonConfig 추가 
- 예약 객실, 숙박일 유효성 검증 로직 구현
- 예약 객실 선점 로직 구현
- 동시성 제어를 위한 Redisson 분산락 사용 로직 구현
- 기능 관련 Custom Exception 추가
- 구현한 기능에 대한 Test 작성
- Rest Docs를 위한 Test 작성
- PayMethod Enum 값 변경

### 🫱🏻‍🫲🏻 To Reviewers
- 🌟🌟🌟🌟 레디스 분산락을 위해 `RedissonClient`을 주입받아 사용하는 `@Service` 빈이 추가되었습니다. 따라서 앞으로 `@SpringBootTest`로 진행되는 모든 Test 클래스에는 Redis Test Container 설정이 되어있는 `AbstractContainersSupport`를 'extends'해서 `@SpringBootTest를 진행해주세요!!!! 🌟🌟🌟🌟

- 📍 `AbstractContainersSupport`에는 `@SpringBootTest` 가 선언되어 있지 않습니다. 'extends' 후 따로 각 테스트 클래스에 `@SpringBootTest`를 추가해주셔야 합니다!!!!!!

This close #42 