### PR TITLE
feat: 주문 취소 기능 개발

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/controller/ReservationRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/controller/ReservationRestController.java
@@ -1,11 +1,15 @@
 package com.fc.shimpyo_be.domain.reservation.controller;
 
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.ReleaseRoomsRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.request.SaveReservationRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.SaveReservationResponseDto;
+import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
 import com.fc.shimpyo_be.domain.reservation.facade.ReservationLockFacade;
 import com.fc.shimpyo_be.domain.reservation.service.ReservationService;
 import com.fc.shimpyo_be.global.common.ResponseDto;
 import com.fc.shimpyo_be.global.util.SecurityUtil;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -14,14 +18,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
-import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
-import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -69,7 +66,9 @@ public class ReservationRestController {
     }
 
     @PostMapping("/preoccupy")
-    public ResponseEntity<ResponseDto<Void>> checkAvailableAndPreoccupy(@Valid @RequestBody PreoccupyRoomsRequestDto request) {
+    public ResponseEntity<ResponseDto<Void>> checkAvailableAndPreoccupy(
+        @Valid @RequestBody PreoccupyRoomsRequestDto request
+    ) {
         log.info("[api][POST] /api/reservations/preoccupy");
 
         preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(securityUtil.getCurrentMemberId(), request);
@@ -78,6 +77,21 @@ public class ReservationRestController {
             .status(HttpStatus.OK)
             .body(
                 ResponseDto.res(HttpStatus.OK, "예약 가능 유효성 검사와 객실 선점이 정상적으로 완료되었습니다.")
+            );
+    }
+
+    @PostMapping("/release")
+    public ResponseEntity<ResponseDto<Void>> releaseRooms(
+        @Valid @RequestBody ReleaseRoomsRequestDto request
+    ) {
+        log.info("[api][POST] /api/reservations/release");
+
+        reservationService.releaseRooms(securityUtil.getCurrentMemberId(), request);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(
+                ResponseDto.res(HttpStatus.OK, "객실 예약 선점이 정상적으로 취소 처리 되었습니다.")
             );
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/ReleaseRoomItemRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/ReleaseRoomItemRequestDto.java
@@ -1,0 +1,14 @@
+package com.fc.shimpyo_be.domain.reservation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record ReleaseRoomItemRequestDto(
+    @NotNull
+    Long roomId,
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 날짜 형식이 아닙니다.(yyyy-MM-dd 형식으로 입력하세요.)")
+    String startDate,
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 날짜 형식이 아닙니다.(yyyy-MM-dd 형식으로 입력하세요.)")
+    String endDate
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/ReleaseRoomsRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/ReleaseRoomsRequestDto.java
@@ -1,0 +1,13 @@
+package com.fc.shimpyo_be.domain.reservation.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ReleaseRoomsRequestDto(
+    @Valid
+    @Size(min = 1, max = 3, message = "최소 1개, 최대 3개의 객실 요청 정보가 필요합니다.")
+    List<ReleaseRoomItemRequestDto> rooms
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/entity/Reservation.java
@@ -57,4 +57,8 @@ public class Reservation extends BaseTimeEntity {
         this.reservationProducts.add(reservationProduct);
         reservationProduct.setReservation(this);
     }
+
+    public void minusPrice(int price) {
+        this.totalPrice -= price;
+    }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/controller/ReservationProductRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/controller/ReservationProductRestController.java
@@ -1,0 +1,34 @@
+package com.fc.shimpyo_be.domain.reservationproduct.controller;
+
+import com.fc.shimpyo_be.domain.reservationproduct.service.ReservationProductService;
+import com.fc.shimpyo_be.global.common.ResponseDto;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/reservation-products")
+@RestController
+public class ReservationProductRestController {
+
+    private final ReservationProductService reservationProductService;
+    private final SecurityUtil securityUtil;
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResponseDto<Void>> cancel(@PathVariable Long id) {
+        log.info("[api][DELETE] /api/reservation-products");
+
+        reservationProductService.cancel(id, securityUtil.getCurrentMemberId());
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ResponseDto.res(HttpStatus.OK, "예약 상품이 정상적으로 취소 처리되었습니다."));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/entity/ReservationProduct.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/entity/ReservationProduct.java
@@ -2,6 +2,7 @@ package com.fc.shimpyo_be.domain.reservationproduct.entity;
 
 import com.fc.shimpyo_be.domain.reservation.entity.Reservation;
 import com.fc.shimpyo_be.domain.room.entity.Room;
+import com.fc.shimpyo_be.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,11 +10,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class ReservationProduct {
+public class ReservationProduct extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,5 +58,9 @@ public class ReservationProduct {
 
     public void setReservation(Reservation reservation) {
         this.reservation = reservation;
+    }
+
+    public void cancel() {
+        this.delete(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/exception/ForbiddenCancelReservationProductException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/exception/ForbiddenCancelReservationProductException.java
@@ -1,0 +1,10 @@
+package com.fc.shimpyo_be.domain.reservationproduct.exception;
+
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+
+public class ForbiddenCancelReservationProductException extends ApplicationException {
+    public ForbiddenCancelReservationProductException() {
+        super(ErrorCode.FORBIDDEN_CANCEL_RESERVATION_PRODUCT);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/exception/ReservationProductNotFoundException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/exception/ReservationProductNotFoundException.java
@@ -1,0 +1,11 @@
+package com.fc.shimpyo_be.domain.reservationproduct.exception;
+
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+
+public class ReservationProductNotFoundException extends ApplicationException {
+
+    public ReservationProductNotFoundException() {
+        super(ErrorCode.RESERVATION_PRODUCT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/repository/ReservationProductRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/repository/ReservationProductRepository.java
@@ -2,8 +2,14 @@ package com.fc.shimpyo_be.domain.reservationproduct.repository;
 
 import com.fc.shimpyo_be.domain.reservationproduct.entity.ReservationProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ReservationProductRepository
     extends JpaRepository<ReservationProduct, Long>, ReservationProductRepositoryCustom {
 
+    @Query("select rp from ReservationProduct rp join fetch rp.reservation where rp.id = :id")
+    Optional<ReservationProduct> findByIdWithReservation(@Param("id") Long id);
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/service/ReservationProductService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/service/ReservationProductService.java
@@ -1,0 +1,37 @@
+package com.fc.shimpyo_be.domain.reservationproduct.service;
+
+import com.fc.shimpyo_be.domain.reservation.entity.Reservation;
+import com.fc.shimpyo_be.domain.reservationproduct.entity.ReservationProduct;
+import com.fc.shimpyo_be.domain.reservationproduct.exception.ForbiddenCancelReservationProductException;
+import com.fc.shimpyo_be.domain.reservationproduct.exception.ReservationProductNotFoundException;
+import com.fc.shimpyo_be.domain.reservationproduct.repository.ReservationProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReservationProductService {
+
+    private final ReservationProductRepository reservationProductRepository;
+
+    @Transactional
+    public void cancel(Long id, Long memberId) {
+        log.info("{} ::: {}", getClass().getSimpleName(), "cancel");
+
+        ReservationProduct reservationProduct = reservationProductRepository.findByIdWithReservation(id)
+            .orElseThrow(ReservationProductNotFoundException::new);
+
+        Reservation reservation = reservationProduct.getReservation();
+
+        // 취소할 권한 확인 후, 에러 처리
+        if(!reservation.getMember().getId().equals(memberId)) {
+            throw new ForbiddenCancelReservationProductException();
+        }
+
+        reservationProduct.cancel();
+        reservation.minusPrice(reservationProduct.getPrice());
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
@@ -27,6 +27,10 @@ public enum ErrorCode {
     LOCK_FAIL(HttpStatus.BAD_REQUEST, "요청 완료에 실패했습니다. 재시도가 필요합니다."),
     INVALID_RESERVATION_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 예약 요청 데이터입니다."),
 
+    // 예약 상품
+    RESERVATION_PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "예약 상품 정보를 찾을 수 없습니다."),
+    FORBIDDEN_CANCEL_RESERVATION_PRODUCT(HttpStatus.FORBIDDEN, "예약 상품을 취소할 권한이 없습니다."),
+
     // 장바구니
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니 정보를 찾을 수 없습니다."),
     CART_NOT_DELETE(HttpStatus.FORBIDDEN, "해당 장바구니를 삭제할 권한이 없습니다"),

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/controller/ReservationRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/controller/ReservationRestControllerTest.java
@@ -2,9 +2,7 @@ package com.fc.shimpyo_be.domain.reservation.unit.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fc.shimpyo_be.config.AbstractContainersSupport;
-import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomItemRequestDto;
-import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
-import com.fc.shimpyo_be.domain.reservation.dto.request.SaveReservationRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.*;
 import com.fc.shimpyo_be.domain.reservation.dto.response.ReservationInfoResponseDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.SaveReservationResponseDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.ValidationResultResponseDto;
@@ -254,6 +252,38 @@ public class ReservationRestControllerTest extends AbstractContainersSupport {
             )
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code", is(400)));
+    }
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("[api][POST][정상] 예약 객실 선점 취소 API")
+    @Test
+    void releaseRooms_test() throws Exception {
+        // given
+        String requestUrl = "/api/reservations/release";
+
+        ReleaseRoomsRequestDto requestDto = new ReleaseRoomsRequestDto(
+            List.of(
+                new ReleaseRoomItemRequestDto(1L, "2023-12-23", "2023-12-25"),
+                new ReleaseRoomItemRequestDto(2L, "2023-11-11", "2023-11-14"),
+                new ReleaseRoomItemRequestDto(3L, "2023-11-15", "2023-11-16")
+            )
+        );
+
+        given(securityUtil.getCurrentMemberId())
+            .willReturn(1L);
+        willDoNothing()
+            .given(reservationService)
+            .releaseRooms(1L, requestDto);
+
+        // when & then
+        mockMvc.perform(
+                post(requestUrl)
+                    .content(objectMapper.writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code", is(200)))
+            .andExpect(jsonPath("$.data").isEmpty());
     }
 
     private ReservationProductRequestDto getReservationProductRequestData(

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/service/ReleaseRoomsServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/service/ReleaseRoomsServiceTest.java
@@ -1,0 +1,93 @@
+package com.fc.shimpyo_be.domain.reservation.unit.service;
+
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
+import com.fc.shimpyo_be.domain.reservation.dto.request.ReleaseRoomItemRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.ReleaseRoomsRequestDto;
+import com.fc.shimpyo_be.domain.reservation.service.ReservationService;
+import com.fc.shimpyo_be.global.util.DateTimeUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class ReleaseRoomsServiceTest extends AbstractContainersSupport {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @DisplayName("선점한 객실을 취소하고, 객실을 릴리즈 한다.")
+    @Test
+    void releaseRooms_test() {
+        //given
+        long roomId1 = 1L;
+        long roomId2 = 2L;
+        long memberId = 3L;
+
+        String startDate1 = "2024-03-01";
+        String endDate1 = "2024-03-04";
+
+        String startDate2 = "2024-02-12";
+        String endDate2 = "2023-02-16";
+
+        saveRedisData(memberId, roomId1, startDate1, endDate1);
+        saveRedisData(memberId, roomId2, startDate2, endDate2);
+
+        ReleaseRoomsRequestDto requestDto = new ReleaseRoomsRequestDto(
+            List.of(
+                new ReleaseRoomItemRequestDto(roomId1, startDate1, endDate1),
+                new ReleaseRoomItemRequestDto(roomId2, startDate2, endDate2)
+            )
+        );
+
+        //when
+        reservationService.releaseRooms(memberId, requestDto);
+
+        //then
+        assertThat(checkResult(roomId1, startDate1, endDate1)).isTrue();
+        assertThat(checkResult(roomId2, startDate2, endDate2)).isTrue();
+    }
+
+    private void saveRedisData(long memberId, long roomId, String startDate, String endDate) {
+        LocalDate targetDate = DateTimeUtil.toLocalDate(startDate);
+        LocalDate lastDate = DateTimeUtil.toLocalDate(endDate);
+        String keyFormat = "roomId:%d:%s";
+
+        while (targetDate.isBefore(lastDate)) {
+            redisTemplate.opsForValue()
+                .set(String.format(keyFormat, roomId, targetDate), String.valueOf(memberId), 60, TimeUnit.SECONDS);
+
+            targetDate = targetDate.plusDays(1);
+        }
+    }
+
+    private boolean checkResult(long roomId, String startDate, String endDate) {
+        LocalDate targetDate = DateTimeUtil.toLocalDate(startDate);
+        LocalDate lastDate = DateTimeUtil.toLocalDate(endDate);
+        String keyFormat = "roomId:%d:%s";
+
+        int totalCount = 0;
+        int nullCount = 0;
+        while (targetDate.isBefore(lastDate)) {
+            if (Objects.isNull(redisTemplate.opsForValue().get(String.format(keyFormat, roomId, targetDate)))) {
+                nullCount++;
+            }
+
+            targetDate = targetDate.plusDays(1);
+            totalCount++;
+        }
+
+        return totalCount == nullCount;
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/reservationproduct/docs/ReservationProductRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservationproduct/docs/ReservationProductRestControllerDocsTest.java
@@ -1,0 +1,46 @@
+package com.fc.shimpyo_be.domain.reservationproduct.docs;
+
+import com.fc.shimpyo_be.config.RestDocsSupport;
+import com.fc.shimpyo_be.domain.reservationproduct.service.ReservationProductService;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ReservationProductRestControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private ReservationProductService reservationProductService;
+
+    @MockBean
+    private SecurityUtil securityUtil;
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("cancel()는 예약 주문 상품을 취소할 수 있다.")
+    @Test
+    void cancel_test() throws Exception {
+        // given
+        String requestUrl = "/api/reservation-products/" + 1;
+
+        given(securityUtil.getCurrentMemberId())
+            .willReturn(1L);
+        willDoNothing()
+            .given(reservationProductService)
+            .cancel(1L, 2L);
+
+        // when
+        mockMvc.perform(delete(requestUrl))
+            .andExpect(status().isOk());
+
+        verify(reservationProductService, times(1)).cancel(anyLong(), anyLong());
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/reservationproduct/unit/controller/ReservationProductRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservationproduct/unit/controller/ReservationProductRestControllerTest.java
@@ -1,0 +1,65 @@
+package com.fc.shimpyo_be.domain.reservationproduct.unit.controller;
+
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
+import com.fc.shimpyo_be.domain.reservationproduct.service.ReservationProductService;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+public class ReservationProductRestControllerTest extends AbstractContainersSupport {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReservationProductService reservationProductService;
+
+    @MockBean
+    private SecurityUtil securityUtil;
+
+    @BeforeEach
+    void setUp(@Autowired WebApplicationContext applicationContext) {
+        this.mockMvc = MockMvcBuilders
+            .webAppContextSetup(applicationContext)
+            .apply(springSecurity())
+            .alwaysDo(print())
+            .build();
+    }
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("[api][DELETE][정상] 예약 주문 상품 취소 API 테스트")
+    @Test
+    void saveReservation_Api_test() throws Exception {
+        //given
+        String requestUrl = "/api/reservation-products/" + 2;
+
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        willDoNothing().given(reservationProductService).cancel(anyLong(), anyLong());
+
+        //when & then
+        mockMvc.perform(
+                delete(requestUrl)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code", is(200)))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/reservationproduct/unit/service/ReservationProductServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservationproduct/unit/service/ReservationProductServiceTest.java
@@ -1,0 +1,137 @@
+package com.fc.shimpyo_be.domain.reservationproduct.unit.service;
+
+import com.fc.shimpyo_be.domain.member.entity.Authority;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.reservation.entity.PayMethod;
+import com.fc.shimpyo_be.domain.reservation.entity.Reservation;
+import com.fc.shimpyo_be.domain.reservationproduct.entity.ReservationProduct;
+import com.fc.shimpyo_be.domain.reservationproduct.exception.ForbiddenCancelReservationProductException;
+import com.fc.shimpyo_be.domain.reservationproduct.exception.ReservationProductNotFoundException;
+import com.fc.shimpyo_be.domain.reservationproduct.repository.ReservationProductRepository;
+import com.fc.shimpyo_be.domain.reservationproduct.service.ReservationProductService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class ReservationProductServiceTest {
+
+    @InjectMocks
+    private ReservationProductService reservationProductService;
+
+    @Mock
+    private ReservationProductRepository reservationProductRepository;
+
+    @DisplayName("예약 상품을 취소할 수 있다.")
+    @Test
+    void cancel_test() {
+        //given
+        Long id = 2L;
+        Long memberId = 1L;
+
+        Member member = Member.builder()
+            .id(memberId)
+            .name("member")
+            .email("member@email.com")
+            .authority(Authority.ROLE_USER)
+            .build();
+
+        Reservation reservation = Reservation.builder()
+            .member(member)
+            .payMethod(PayMethod.KAKAO_PAY)
+            .totalPrice(300000)
+            .build();
+
+        int beforePrice = reservation.getTotalPrice();
+
+        ReservationProduct reservationProduct = ReservationProduct.builder()
+            .id(2L)
+            .reservation(reservation)
+            .price(150000)
+            .startDate(LocalDate.of(2024, 2, 3))
+            .endDate(LocalDate.of(2024, 2, 5))
+            .build();
+
+        given(reservationProductRepository.findByIdWithReservation(anyLong()))
+            .willReturn(Optional.of(reservationProduct));
+
+        //when
+        reservationProductService.cancel(id, memberId);
+
+        //then
+        assertThat(reservation.getTotalPrice()).isEqualTo(beforePrice - reservationProduct.getPrice());
+        assertThat(reservationProduct.isDeleted()).isTrue();
+
+        verify(reservationProductRepository, times(1)).findByIdWithReservation(anyLong());
+    }
+
+    @DisplayName("예약 상품 정보가 존재하지 않으면, 예약 상품을 취소할 수 있다.")
+    @Test
+    void cancel_reservationProductNotFound_test() {
+        //given
+        Long id = 2L;
+        Long memberId = 1L;
+
+        given(reservationProductRepository.findByIdWithReservation(anyLong()))
+            .willThrow(ReservationProductNotFoundException.class);
+
+        //when & then
+        assertThatThrownBy(() -> reservationProductService.cancel(id, memberId))
+            .isInstanceOf(ReservationProductNotFoundException.class);
+
+        verify(reservationProductRepository, times(1)).findByIdWithReservation(anyLong());
+    }
+
+    @DisplayName("예약 상품 주문자 정보와 현재 인증 객체 정보가 일치하지 않으며, 예약 상품을 취소할 수 없다.")
+    @Test
+    void cancel_forbidden_test() {
+        //given
+        Long id = 2L;
+        Long memberId = 100L;
+
+        Member member = Member.builder()
+            .id(1L)
+            .name("member")
+            .email("member@email.com")
+            .authority(Authority.ROLE_USER)
+            .build();
+
+        Reservation reservation = Reservation.builder()
+            .member(member)
+            .payMethod(PayMethod.KAKAO_PAY)
+            .totalPrice(300000)
+            .build();
+
+        ReservationProduct reservationProduct = ReservationProduct.builder()
+            .id(2L)
+            .reservation(reservation)
+            .price(150000)
+            .startDate(LocalDate.of(2024, 2, 3))
+            .endDate(LocalDate.of(2024, 2, 5))
+            .build();
+
+        given(reservationProductRepository.findByIdWithReservation(anyLong()))
+            .willReturn(Optional.of(reservationProduct));
+
+        //when
+        assertThatThrownBy(() -> reservationProductService.cancel(id, memberId))
+            .isInstanceOf(ForbiddenCancelReservationProductException.class);
+
+        // then
+        verify(reservationProductRepository, times(1)).findByIdWithReservation(anyLong());
+    }
+}


### PR DESCRIPTION
### 💡 Motivation
- 선점한 객실을 선점 취소하는 기능과 이미 결제된 예약 주문 상품을 취소하는 기능을 개발합니다.

### 📌 Changes
- 선점 취소 기능 관련 Request/Response DTO 추가
- 선점 취소 기능 비즈니스 로직 구현
- 선점 취소 API 구현
- 예약 상품 취소를 위한 도메인 비즈니스 로직 메서드 추가
- 예약 상품 취소 서비스 로직 구현 
- 예약 상품 취소 API 구현
- ErrorCode 추가 및 Custom Exception 추가
- 구현한 기능에 대한 Unit Test 작성
- Rest Docs를 위한 Test 작성

### 🫱🏻‍🫲🏻 To Reviewers
- 현재 프로젝트 기간 필수 기능은 아니고 추후 고도화 기간에 추가될 수 있는 기능입니다!

This close #53 