### PR TITLE
fix: 예약 API 버그 해결

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
@@ -65,7 +65,7 @@ public class PreoccupyRoomsService {
             Map<String, String> map = preoccupyMap.get(room.roomId());
             opsForValue.multiSet(map);
 
-            Date expireDate = convertLocalDateToDate(DateTimeUtil.toLocalDate(room.endDate()).minusDays(1));
+            Date expireDate = convertLocalDateToDate(DateTimeUtil.toLocalDate(room.endDate()));
             for (String key : map.keySet()) {
                 redisTemplate.expireAt(key, expireDate);
             }


### PR DESCRIPTION
### 💡 Motivation
- 예약 API 호출시 NullPointerException 발생했습니다.

### 📌 Changes
- PreoccupyRoomsService의 preoccupy 선점 메서드에서 Redis 키 값의 만료기한 설정을 수정
   - 기존: 숙박 endDate 하루 전
   - 변경: 숙박 endDate와 동일

This close #58 