### PR TITLE
fix: 객실 조회에서 fetchJoin을 사용하면 너무 많은 데이터가 영속성 컨텍스트에 저장되, 서버 메모리가 버티질 못함. 

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/product/repository/ProductCustomRepositoryImpl.java
@@ -1,18 +1,32 @@
 package com.fc.shimpyo_be.domain.product.repository;
 
 
+import static com.fc.shimpyo_be.domain.product.entity.QAddress.address1;
+import static com.fc.shimpyo_be.domain.product.entity.QProduct.product;
+import static com.fc.shimpyo_be.domain.reservation.entity.QReservation.reservation;
+import static com.fc.shimpyo_be.domain.reservationproduct.entity.QReservationProduct.reservationProduct;
+import static com.fc.shimpyo_be.domain.room.entity.QRoom.room;
+
 import com.fc.shimpyo_be.domain.product.dto.request.SearchKeywordRequest;
 import com.fc.shimpyo_be.domain.product.entity.Product;
 import com.fc.shimpyo_be.domain.product.entity.QAddress;
 import com.fc.shimpyo_be.domain.product.entity.QProduct;
 import com.fc.shimpyo_be.domain.room.entity.QRoom;
+import com.fc.shimpyo_be.global.util.QueryDslUtil;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.ObjectUtils;
 
 
 @Repository
@@ -27,23 +41,64 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
     public Page<Product> findAllBySearchKeywordRequest(SearchKeywordRequest searchKeywordRequest,
         Pageable pageable) {
 
-        QProduct product = QProduct.product;
-        QRoom room = QRoom.room;
-        QAddress address = QAddress.address1;
-
         JPAQuery<Product> query = queryFactory
             .selectDistinct(product)
             .from(product)
             .leftJoin(product.rooms, room).fetchJoin()
-            .leftJoin(product.address, address).fetchJoin()
-            .where(product.name.likeIgnoreCase("%" + searchKeywordRequest.productName() + "%"),
-                address.detailAddress.likeIgnoreCase("%" + searchKeywordRequest.address() + "%"),
-                product.category.in(searchKeywordRequest.category()),
-                room.capacity.goe(searchKeywordRequest.capacity()))
+            .leftJoin(product.address, address1).fetchJoin()
+            .where(buildSearchConditions(searchKeywordRequest))
             .offset(pageable.getOffset())
+            .orderBy(getAllOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new))
             .limit(pageable.getPageSize());
 
         List<Product> content = query.fetch();
         return PageableExecutionUtils.getPage(content, pageable, query::fetchCount);
     }
+
+    private BooleanExpression buildSearchConditions(SearchKeywordRequest searchKeywordRequest) {
+        List<BooleanExpression> expressions = new ArrayList<>();
+
+        if (searchKeywordRequest.productName() != null) {
+            expressions.add(product.name.containsIgnoreCase(searchKeywordRequest.productName()));
+        }
+
+        if (searchKeywordRequest.address() != null) {
+            expressions.add(address1.detailAddress.containsIgnoreCase(searchKeywordRequest.address()));
+        }
+
+        if (searchKeywordRequest.category() != null && !searchKeywordRequest.category().isEmpty()) {
+            expressions.add(product.category.in(searchKeywordRequest.category()));
+        }
+
+        if (searchKeywordRequest.capacity() != null) {
+            expressions.add(room.capacity.goe(searchKeywordRequest.capacity()));
+        }
+
+        return expressions.stream().reduce(BooleanExpression::and).orElse(null);
+    }
+
+
+    private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
+
+        List<OrderSpecifier<?>> ORDERS = new LinkedList<>();
+
+        if (!ObjectUtils.isEmpty(pageable.getSort())) {
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                switch (order.getProperty()) {
+                    case "starAvg" -> {
+                        OrderSpecifier<?> orderId = QueryDslUtil.getSortedColumn(direction, product, "starAvg");
+                        ORDERS.add(orderId);
+                    }
+                }
+            }
+        }
+
+        if(ORDERS.isEmpty()) {
+            ORDERS.add(QueryDslUtil.getSortedColumn(Order.DESC, product, "starAvg"));
+        }
+
+        return ORDERS;
+    }
+
 }


### PR DESCRIPTION
### 💡 Motivation
- 방 데이터와 숙소 주소를 fetch join하고자 하니까, 서버 heap 영역이 가득차버림...제목 그대로 ㅜㅜ

### 📌 Changes
- 전체 조회에서 fetch join 삭제

### 🫱🏻‍🫲🏻 To Reviewers
- 추가적으로 우려가 되는 부분이 있으면 말씀 부탁드립니다.