### PR TITLE
refactor: 객실 예약 가능 확인 및 선점 API 로직 수정

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/controller/ReservationRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/controller/ReservationRestController.java
@@ -4,6 +4,7 @@ import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto
 import com.fc.shimpyo_be.domain.reservation.dto.request.ReleaseRoomsRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.request.SaveReservationRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.SaveReservationResponseDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidatePreoccupyResultResponseDto;
 import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
 import com.fc.shimpyo_be.domain.reservation.facade.ReservationLockFacade;
 import com.fc.shimpyo_be.domain.reservation.service.ReservationService;
@@ -35,7 +36,7 @@ public class ReservationRestController {
     public ResponseEntity<ResponseDto<SaveReservationResponseDto>> saveReservation(
         @Valid @RequestBody SaveReservationRequestDto request
     ) {
-        log.info("[api][POST] /api/reservations");
+        log.debug("[api][POST] /api/reservations");
 
         return ResponseEntity
             .status(HttpStatus.CREATED)
@@ -52,7 +53,7 @@ public class ReservationRestController {
     public ResponseEntity<ResponseDto<Page<?>>> getReservationList(
         @PageableDefault(size = 10, page = 0, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        log.info("[api][GET] /api/reservations");
+        log.debug("[api][GET] /api/reservations");
 
         return ResponseEntity
             .status(HttpStatus.OK)
@@ -66,17 +67,19 @@ public class ReservationRestController {
     }
 
     @PostMapping("/preoccupy")
-    public ResponseEntity<ResponseDto<Void>> checkAvailableAndPreoccupy(
+    public ResponseEntity<ResponseDto<ValidatePreoccupyResultResponseDto>> checkAvailableAndPreoccupy(
         @Valid @RequestBody PreoccupyRoomsRequestDto request
     ) {
-        log.info("[api][POST] /api/reservations/preoccupy");
-
-        preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(securityUtil.getCurrentMemberId(), request);
+        log.debug("[api][POST] /api/reservations/preoccupy");
 
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
-                ResponseDto.res(HttpStatus.OK, "예약 가능 유효성 검사와 객실 선점이 정상적으로 완료되었습니다.")
+                ResponseDto.res(
+                    HttpStatus.OK,
+                    preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(securityUtil.getCurrentMemberId(), request),
+                    "예약 가능 유효성 검사와 객실 선점이 정상적으로 완료되었습니다."
+                )
             );
     }
 
@@ -84,7 +87,7 @@ public class ReservationRestController {
     public ResponseEntity<ResponseDto<Void>> releaseRooms(
         @Valid @RequestBody ReleaseRoomsRequestDto request
     ) {
-        log.info("[api][POST] /api/reservations/release");
+        log.debug("[api][POST] /api/reservations/release");
 
         reservationService.releaseRooms(securityUtil.getCurrentMemberId(), request);
 

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/CheckAvailableRoomsResultDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/CheckAvailableRoomsResultDto.java
@@ -1,5 +1,6 @@
 package com.fc.shimpyo_be.domain.reservation.dto;
 
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidatePreoccupyRoomResponseDto;
 import lombok.Builder;
 
 import java.util.List;
@@ -8,7 +9,7 @@ import java.util.Map;
 @Builder
 public record CheckAvailableRoomsResultDto(
     boolean isAvailable,
-    List<Long> unavailableIds,
-    Map<Long, Map<String, String>> recordMap
+    List<ValidatePreoccupyRoomResponseDto> roomResults,
+    Map<Long, Map<String, String>> preoccupyMap
 ) {
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/PreoccupyRoomItemRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/PreoccupyRoomItemRequestDto.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 @Builder
 public record PreoccupyRoomItemRequestDto(
     @NotNull
-    Long roomId,
+    Long roomCode,
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 날짜 형식이 아닙니다.(yyyy-MM-dd 형식으로 입력하세요.)")
     String startDate,
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 날짜 형식이 아닙니다.(yyyy-MM-dd 형식으로 입력하세요.)")

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/ValidatePreoccupyResultResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/ValidatePreoccupyResultResponseDto.java
@@ -1,0 +1,12 @@
+package com.fc.shimpyo_be.domain.reservation.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ValidatePreoccupyResultResponseDto(
+    boolean isAvailable,
+    List<ValidatePreoccupyRoomResponseDto> roomResults
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/ValidatePreoccupyRoomResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/ValidatePreoccupyRoomResponseDto.java
@@ -1,0 +1,12 @@
+package com.fc.shimpyo_be.domain.reservation.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ValidatePreoccupyRoomResponseDto(
+    Long roomCode,
+    String startDate,
+    String endDate,
+    Long roomId
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/ValidateReservationResultResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/ValidateReservationResultResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record ValidationResultResponseDto(
+public record ValidateReservationResultResponseDto(
     boolean isAvailable,
     List<Long> unavailableIds
 ) {

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/PreoccupyNotAvailableException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/PreoccupyNotAvailableException.java
@@ -1,21 +1,21 @@
 package com.fc.shimpyo_be.domain.reservation.exception;
 
-import com.fc.shimpyo_be.domain.reservation.dto.response.ValidationResultResponseDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidatePreoccupyResultResponseDto;
 import com.fc.shimpyo_be.global.exception.ErrorCode;
 import lombok.Getter;
 
 @Getter
-public class UnavailableRoomsException extends RuntimeException {
+public class PreoccupyNotAvailableException extends RuntimeException {
 
     private final ErrorCode errorCode;
-    private ValidationResultResponseDto data;
+    private ValidatePreoccupyResultResponseDto data;
 
-    public UnavailableRoomsException() {
+    public PreoccupyNotAvailableException() {
         super(ErrorCode.UNAVAILABLE_ROOMS.getSimpleMessage());
         this.errorCode = ErrorCode.UNAVAILABLE_ROOMS;
     }
 
-    public UnavailableRoomsException(ValidationResultResponseDto data) {
+    public PreoccupyNotAvailableException(ValidatePreoccupyResultResponseDto data) {
         super(ErrorCode.UNAVAILABLE_ROOMS.getSimpleMessage());
         this.errorCode = ErrorCode.UNAVAILABLE_ROOMS;
         this.data = data;

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/ReservationRestControllerAdvice.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/ReservationRestControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.fc.shimpyo_be.domain.reservation.exception;
 
-import com.fc.shimpyo_be.domain.reservation.dto.response.ValidationResultResponseDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidateReservationResultResponseDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidatePreoccupyResultResponseDto;
 import com.fc.shimpyo_be.global.common.ResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,9 +12,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ReservationRestControllerAdvice {
 
-    @ExceptionHandler(UnavailableRoomsException.class)
-    public ResponseEntity<ResponseDto<ValidationResultResponseDto>> unavailableRoomsException(
-        UnavailableRoomsException e) {
+    @ExceptionHandler(ReserveNotAvailableException.class)
+    public ResponseEntity<ResponseDto<ValidateReservationResultResponseDto>> unavailableToReserveException(
+        ReserveNotAvailableException e) {
+        return ResponseEntity
+            .status(e.getErrorCode().getHttpStatus())
+            .body(ResponseDto.res(e.getErrorCode().getHttpStatus(), e.getData(), e.getMessage()));
+    }
+
+    @ExceptionHandler(PreoccupyNotAvailableException.class)
+    public ResponseEntity<ResponseDto<ValidatePreoccupyResultResponseDto>> unavailableToPreoccupyException(
+        PreoccupyNotAvailableException e) {
         return ResponseEntity
             .status(e.getErrorCode().getHttpStatus())
             .body(ResponseDto.res(e.getErrorCode().getHttpStatus(), e.getData(), e.getMessage()));

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/ReserveNotAvailableException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/ReserveNotAvailableException.java
@@ -1,0 +1,23 @@
+package com.fc.shimpyo_be.domain.reservation.exception;
+
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidateReservationResultResponseDto;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ReserveNotAvailableException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private ValidateReservationResultResponseDto data;
+
+    public ReserveNotAvailableException() {
+        super(ErrorCode.UNAVAILABLE_ROOMS.getSimpleMessage());
+        this.errorCode = ErrorCode.UNAVAILABLE_ROOMS;
+    }
+
+    public ReserveNotAvailableException(ValidateReservationResultResponseDto data) {
+        super(ErrorCode.UNAVAILABLE_ROOMS.getSimpleMessage());
+        this.errorCode = ErrorCode.UNAVAILABLE_ROOMS;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
@@ -36,7 +36,6 @@ public class PreoccupyRoomsService {
         Set<String> checkSet = new HashSet<>();
         List<ValidatePreoccupyRoomResponseDto> roomResults = new ArrayList<>();
 
-        // 각 요청 데이터 처리
         for (PreoccupyRoomItemRequestDto room : request.rooms()) {
 
             LocalDate startDate = DateTimeUtil.toLocalDate(room.startDate());
@@ -45,8 +44,6 @@ public class PreoccupyRoomsService {
 
             List<Long> roomIds = roomService.getRoomIdsByCode(roomCode);
 
-            // roomId 돌면서 되는지 확인
-            // 되는 경우
             boolean roomIdCheck = false;
             for (Long roomId : roomIds) {
 

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/service/ReservationService.java
@@ -9,7 +9,7 @@ import com.fc.shimpyo_be.domain.reservation.dto.request.ReleaseRoomsRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.request.SaveReservationRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.ReservationInfoResponseDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.SaveReservationResponseDto;
-import com.fc.shimpyo_be.domain.reservation.dto.response.ValidationResultResponseDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidateReservationResultResponseDto;
 import com.fc.shimpyo_be.domain.reservation.entity.Reservation;
 import com.fc.shimpyo_be.domain.reservation.exception.InvalidRequestException;
 import com.fc.shimpyo_be.domain.reservation.repository.ReservationRepository;
@@ -51,7 +51,7 @@ public class ReservationService {
 
     @Transactional
     public SaveReservationResponseDto saveReservation(Long memberId, SaveReservationRequestDto request) {
-        log.info("{} ::: {}", getClass().getSimpleName(), "saveReservation");
+        log.debug("{} ::: {}", getClass().getSimpleName(), "saveReservation");
 
         // 회원 엔티티 조회
         Member member = memberRepository.findById(memberId)
@@ -90,7 +90,7 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public Page<ReservationInfoResponseDto> getReservationInfoList(Long memberId, Pageable pageable) {
-        log.info("{} ::: {}", getClass().getSimpleName(), "getReservationInfoList");
+        log.debug("{} ::: {}", getClass().getSimpleName(), "getReservationInfoList");
 
         List<Long> reservationIds = reservationRepository.findIdsByMemberId(memberId);
 
@@ -99,8 +99,8 @@ public class ReservationService {
             .map(ReservationMapper::from);
     }
 
-    public ValidationResultResponseDto validate(Long memberId, List<ReservationProductRequestDto> reservationProducts) {
-        log.info("{} ::: {}", getClass().getSimpleName(), "validate");
+    public ValidateReservationResultResponseDto validate(Long memberId, List<ReservationProductRequestDto> reservationProducts) {
+        log.debug("{} ::: {}", getClass().getSimpleName(), "validate");
 
         ValueOperations<String, Object> opsForValue = redisTemplate.opsForValue();
 
@@ -132,11 +132,14 @@ public class ReservationService {
             }
         }
 
-        return new ValidationResultResponseDto(isValid, invalidRoomIds);
+        return ValidateReservationResultResponseDto.builder()
+            .isAvailable(isValid)
+            .unavailableIds(invalidRoomIds)
+            .build();
     }
 
     public void releaseRooms(Long memberId, ReleaseRoomsRequestDto request) {
-        log.info("{} ::: {}", getClass().getSimpleName(), "releaseRooms");
+        log.debug("{} ::: {}", getClass().getSimpleName(), "releaseRooms");
 
         String memberIdValue = String.valueOf(memberId);
         ValueOperations<String, Object> opsForValue = redisTemplate.opsForValue();

--- a/src/main/java/com/fc/shimpyo_be/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/room/repository/RoomRepository.java
@@ -2,8 +2,14 @@ package com.fc.shimpyo_be.domain.room.repository;
 
 import com.fc.shimpyo_be.domain.room.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface RoomRepository
     extends JpaRepository<Room, Long>, RoomRepositoryCustom {
 
+    @Query("select r.id from Room r where r.code = :code")
+    List<Long> findIdsByCode(@Param("code") Long code);
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/room/service/RoomService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/room/service/RoomService.java
@@ -27,4 +27,10 @@ public class RoomService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<Long> getRoomIdsByCode(Long roomCode) {
+        log.debug("{} ::: {}", getClass().getSimpleName(), "getRoomIdListByRoomCode");
+
+        return roomRepository.findIdsByCode(roomCode);
+    }
 }

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/docs/ReservationRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/docs/ReservationRestControllerDocsTest.java
@@ -4,6 +4,8 @@ import com.fc.shimpyo_be.config.RestDocsSupport;
 import com.fc.shimpyo_be.domain.reservation.dto.request.*;
 import com.fc.shimpyo_be.domain.reservation.dto.response.ReservationInfoResponseDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.SaveReservationResponseDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidatePreoccupyResultResponseDto;
+import com.fc.shimpyo_be.domain.reservation.dto.response.ValidatePreoccupyRoomResponseDto;
 import com.fc.shimpyo_be.domain.reservation.entity.PayMethod;
 import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
 import com.fc.shimpyo_be.domain.reservation.facade.ReservationLockFacade;
@@ -261,22 +263,22 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                     responseFields(responseCommon()).and(
                         fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
                         fieldWithPath("data.content").type(JsonFieldType.ARRAY).description("조회 데이터 리스트"),
-                        fieldWithPath("data.content.[].reservationId").type(JsonFieldType.NUMBER).description("예약 식별자"),
-                        fieldWithPath("data.content.[].reservationProductId").type(JsonFieldType.NUMBER).description("예약 숙소 식별자"),
-                        fieldWithPath("data.content.[].productId").type(JsonFieldType.NUMBER).description("숙소 식별자"),
-                        fieldWithPath("data.content.[].productName").type(JsonFieldType.STRING).description("숙소명"),
-                        fieldWithPath("data.content.[].productImageUrl").type(JsonFieldType.STRING).description("숙소 대표 이미지 URL"),
-                        fieldWithPath("data.content.[].productAddress").type(JsonFieldType.STRING).description("숙소 주소"),
-                        fieldWithPath("data.content.[].productDetailAddress").type(JsonFieldType.STRING).description("숙소 상세 주소"),
-                        fieldWithPath("data.content.[].roomId").type(JsonFieldType.NUMBER).description("예약한 객실 식별자"),
-                        fieldWithPath("data.content.[].roomName").type(JsonFieldType.STRING).description("객실명"),
-                        fieldWithPath("data.content.[].startDate").type(JsonFieldType.STRING).description("숙박 시작일"),
-                        fieldWithPath("data.content.[].endDate").type(JsonFieldType.STRING).description("숙박 마지막일"),
-                        fieldWithPath("data.content.[].checkIn").type(JsonFieldType.STRING).description("체크인 시간"),
-                        fieldWithPath("data.content.[].checkOut").type(JsonFieldType.STRING).description("체크아웃 시간"),
-                        fieldWithPath("data.content.[].price").type(JsonFieldType.NUMBER).description("결제 금액"),
-                        fieldWithPath("data.content.[].payMethod").type(JsonFieldType.STRING).description("결제 수단"),
-                        fieldWithPath("data.content.[].createdAt").type(JsonFieldType.STRING).description("예약 결제 완료 일시"),
+                        fieldWithPath("data.content[].reservationId").type(JsonFieldType.NUMBER).description("예약 식별자"),
+                        fieldWithPath("data.content[].reservationProductId").type(JsonFieldType.NUMBER).description("예약 숙소 식별자"),
+                        fieldWithPath("data.content[].productId").type(JsonFieldType.NUMBER).description("숙소 식별자"),
+                        fieldWithPath("data.content[].productName").type(JsonFieldType.STRING).description("숙소명"),
+                        fieldWithPath("data.content[].productImageUrl").type(JsonFieldType.STRING).description("숙소 대표 이미지 URL"),
+                        fieldWithPath("data.content[].productAddress").type(JsonFieldType.STRING).description("숙소 주소"),
+                        fieldWithPath("data.content[].productDetailAddress").type(JsonFieldType.STRING).description("숙소 상세 주소"),
+                        fieldWithPath("data.content[].roomId").type(JsonFieldType.NUMBER).description("예약한 객실 식별자"),
+                        fieldWithPath("data.content[].roomName").type(JsonFieldType.STRING).description("객실명"),
+                        fieldWithPath("data.content[].startDate").type(JsonFieldType.STRING).description("숙박 시작일"),
+                        fieldWithPath("data.content[].endDate").type(JsonFieldType.STRING).description("숙박 마지막일"),
+                        fieldWithPath("data.content[].checkIn").type(JsonFieldType.STRING).description("체크인 시간"),
+                        fieldWithPath("data.content[].checkOut").type(JsonFieldType.STRING).description("체크아웃 시간"),
+                        fieldWithPath("data.content[].price").type(JsonFieldType.NUMBER).description("결제 금액"),
+                        fieldWithPath("data.content[].payMethod").type(JsonFieldType.STRING).description("결제 수단"),
+                        fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("예약 결제 완료 일시"),
 
                         fieldWithPath("data.pageable.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬 여부"),
                         fieldWithPath("data.pageable.sort.empty").type(JsonFieldType.BOOLEAN).description("데이터가 비었는지 여부"),
@@ -317,10 +319,31 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                 .rooms(
                     List.of(
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomId(1L).startDate("2023-12-23").endDate("2023-12-25")
+                            .roomCode(1001L).startDate("2023-12-23").endDate("2023-12-25")
                             .build(),
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomId(2L).startDate("2023-11-11").endDate("2023-11-14")
+                            .roomCode(1002L).startDate("2023-11-11").endDate("2023-11-14")
+                            .build()
+                    )
+                )
+                .build();
+
+        ValidatePreoccupyResultResponseDto responseDto =
+            ValidatePreoccupyResultResponseDto.builder()
+                .isAvailable(true)
+                .roomResults(
+                    List.of(
+                        ValidatePreoccupyRoomResponseDto.builder()
+                            .roomCode(1001L)
+                            .startDate("2023-12-23")
+                            .endDate("2023-12-25")
+                            .roomId(1L)
+                            .build(),
+                        ValidatePreoccupyRoomResponseDto.builder()
+                            .roomCode(1002L)
+                            .startDate("2023-11-11")
+                            .endDate("2023-11-14")
+                            .roomId(3L)
                             .build()
                     )
                 )
@@ -328,9 +351,8 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
 
         given(securityUtil.getCurrentMemberId())
             .willReturn(1L);
-        willDoNothing()
-            .given(preoccupyRoomsLockFacade)
-            .checkAvailableAndPreoccupy(1L, requestDto);
+        given(preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(1L, requestDto))
+            .willReturn(responseDto);
 
         // when
         mockMvc.perform(post(requestUrl)
@@ -342,9 +364,9 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                         fieldWithPath("rooms").type(JsonFieldType.ARRAY).description("예약할 객실 리스트")
                             .attributes(key("constraints").value(
                                 preoccupyRoomsDescriptions.descriptionsForProperty("rooms"))),
-                        fieldWithPath("rooms[].roomId").type(JsonFieldType.NUMBER).description("예약할 객실 식별자")
+                        fieldWithPath("rooms[].roomCode").type(JsonFieldType.NUMBER).description("예약할 객실 코드")
                             .attributes(key("constraints").value(
-                                preoccupyRoomItemDescriptions.descriptionsForProperty("roomId"))),
+                                preoccupyRoomItemDescriptions.descriptionsForProperty("roomCode"))),
                         fieldWithPath("rooms[].startDate").type(JsonFieldType.STRING).description("숙박 시작일")
                             .attributes(key("constraints").value(
                                 preoccupyRoomItemDescriptions.descriptionsForProperty("startDate"))),
@@ -353,7 +375,13 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                                 preoccupyRoomItemDescriptions.descriptionsForProperty("endDate")))
                     ),
                     responseFields(responseCommon()).and(
-                        fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터")
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                        fieldWithPath("data.isAvailable").type(JsonFieldType.BOOLEAN).description("예약 선점 가능 여부"),
+                        fieldWithPath("data.roomResults").type(JsonFieldType.ARRAY).description("객실별 예약 선점 가능 검증 결과 리스트"),
+                        fieldWithPath("data.roomResults[].roomCode").type(JsonFieldType.NUMBER).description("객실 코드"),
+                        fieldWithPath("data.roomResults[].startDate").type(JsonFieldType.STRING).description("숙박 시작일"),
+                        fieldWithPath("data.roomResults[].endDate").type(JsonFieldType.STRING).description("숙박 마지막일"),
+                        fieldWithPath("data.roomResults[].roomId").type(JsonFieldType.NUMBER).description("매칭된 객실 식별자 (-1인 경우, 예약 선점 불가능한 객실)")
                     )
                 )
             );

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/facade/PreoccupyRoomsLockFacadeTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/facade/PreoccupyRoomsLockFacadeTest.java
@@ -1,28 +1,190 @@
 package com.fc.shimpyo_be.domain.reservation.unit.facade;
 
 import com.fc.shimpyo_be.config.AbstractContainersSupport;
+import com.fc.shimpyo_be.config.DatabaseCleanUp;
+import com.fc.shimpyo_be.config.TestDBCleanerConfig;
+import com.fc.shimpyo_be.domain.product.entity.*;
+import com.fc.shimpyo_be.domain.product.repository.ProductRepository;
 import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomItemRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
 import com.fc.shimpyo_be.domain.reservation.facade.PreoccupyRoomsLockFacade;
+import com.fc.shimpyo_be.domain.room.entity.Room;
+import com.fc.shimpyo_be.domain.room.entity.RoomOption;
+import com.fc.shimpyo_be.domain.room.entity.RoomPrice;
+import com.fc.shimpyo_be.domain.room.repository.RoomRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.util.StopWatch;
 
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
+@Import(TestDBCleanerConfig.class)
 @SpringBootTest
 public class PreoccupyRoomsLockFacadeTest extends AbstractContainersSupport {
 
     @Autowired
     private PreoccupyRoomsLockFacade preoccupyRoomsLockFacade;
 
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private final String[] tableNameArray
+        = {"product", "product_option", "address", "room", "room_option", "amenity", "room_price"};
+
     private static final ThreadLocal<StopWatch> threadLocalStopWatch = ThreadLocal.withInitial(StopWatch::new);
+
+    @BeforeEach
+    void setUp() {
+        databaseCleanUp.cleanUp(tableNameArray);
+
+        List<Product> products = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            String productName = "호텔" + i;
+            float starAvg = ThreadLocalRandom.current().nextFloat(0, 5);
+            String infoCenter = String.format("02-1234-%d%d%d%d", i, i, i, i);
+            products.add(
+                productRepository.save(
+                    Product.builder()
+                        .name(productName)
+                        .thumbnail(productName + " 썸네일 url")
+                        .description(productName + " 설명")
+                        .starAvg(starAvg)
+                        .category(Category.TOURIST_HOTEL)
+                        .address(
+                            Address.builder()
+                                .address(productName + " 주소")
+                                .detailAddress(productName + " 상세 주소")
+                                .mapX(1.0)
+                                .mapY(1.5)
+                                .build()
+                        )
+                        .productOption(
+                            ProductOption.builder()
+                                .cooking(true)
+                                .foodPlace("음료 가능")
+                                .parking(true)
+                                .pickup(false)
+                                .infoCenter(infoCenter)
+                                .build()
+                        )
+                        .amenity(
+                            Amenity.builder()
+                                .barbecue(false)
+                                .beauty(true)
+                                .beverage(true)
+                                .fitness(true)
+                                .bicycle(false)
+                                .campfire(false)
+                                .karaoke(true)
+                                .publicBath(true)
+                                .publicPc(true)
+                                .seminar(false)
+                                .sports(false)
+                                .build()
+                        )
+                        .build()
+                )
+            );
+        }
+
+        for (int i = 1; i <= 3; i++) {
+            String roomName = "객실" + i;
+            roomRepository.save(
+                Room.builder()
+                    .product(products.get(i - 1))
+                    .name(roomName)
+                    .code(1000 + i)
+                    .description(roomName + " 설명")
+                    .standard(2)
+                    .capacity(4)
+                    .checkIn(LocalTime.of(14, 0))
+                    .checkOut(LocalTime.of(12, 0))
+                    .price(
+                        RoomPrice.builder()
+                            .offWeekDaysMinFee(75000)
+                            .offWeekendMinFee(85000)
+                            .peakWeekDaysMinFee(100000)
+                            .peakWeekendMinFee(120000)
+                            .build()
+                    )
+                    .roomOption(
+                        RoomOption.builder()
+                            .cooking(true)
+                            .airCondition(true)
+                            .bath(true)
+                            .bathFacility(true)
+                            .pc(false)
+                            .diningTable(true)
+                            .hairDryer(true)
+                            .homeTheater(false)
+                            .internet(true)
+                            .cable(false)
+                            .refrigerator(true)
+                            .sofa(true)
+                            .toiletries(true)
+                            .tv(true)
+                            .build()
+                    )
+                    .build()
+            );
+        }
+
+        roomRepository.save(
+            Room.builder()
+                .product(products.get(0))
+                .name("객실1")
+                .code(1001)
+                .description("객실1 설명")
+                .standard(2)
+                .capacity(4)
+                .checkIn(LocalTime.of(14, 0))
+                .checkOut(LocalTime.of(12, 0))
+                .price(
+                    RoomPrice.builder()
+                        .offWeekDaysMinFee(75000)
+                        .offWeekendMinFee(85000)
+                        .peakWeekDaysMinFee(100000)
+                        .peakWeekendMinFee(120000)
+                        .build()
+                )
+                .roomOption(
+                    RoomOption.builder()
+                        .cooking(true)
+                        .airCondition(true)
+                        .bath(true)
+                        .bathFacility(true)
+                        .pc(false)
+                        .diningTable(true)
+                        .hairDryer(true)
+                        .homeTheater(false)
+                        .internet(true)
+                        .cable(false)
+                        .refrigerator(true)
+                        .sofa(true)
+                        .toiletries(true)
+                        .tv(true)
+                        .build()
+                )
+                .build()
+        );
+    }
 
     @Test
     void checkAvailable() throws InterruptedException {
@@ -32,26 +194,90 @@ public class PreoccupyRoomsLockFacadeTest extends AbstractContainersSupport {
         ExecutorService executors = Executors.newFixedThreadPool(poolSize);
         CountDownLatch latch = new CountDownLatch(threadSize);
 
-        PreoccupyRoomsRequestDto request1 = new PreoccupyRoomsRequestDto(List.of(
-            new PreoccupyRoomItemRequestDto(1L, "2024-03-05", "2024-03-08"),
-            new PreoccupyRoomItemRequestDto(2L, "2024-04-05", "2024-04-09")
-        ));
-        PreoccupyRoomsRequestDto request2 = new PreoccupyRoomsRequestDto(List.of(
-            new PreoccupyRoomItemRequestDto(1L, "2024-03-06", "2024-03-09"),
-            new PreoccupyRoomItemRequestDto(2L, "2024-04-04", "2024-04-06")
-        ));
-        PreoccupyRoomsRequestDto request3 = new PreoccupyRoomsRequestDto(List.of(
-            new PreoccupyRoomItemRequestDto(1L, "2024-02-10", "2024-02-15"),
-            new PreoccupyRoomItemRequestDto(3L, "2024-04-05", "2024-04-09")
-        ));
-        PreoccupyRoomsRequestDto request4 = new PreoccupyRoomsRequestDto(List.of(
-            new PreoccupyRoomItemRequestDto(3L, "2024-04-04", "2024-04-08")
-        ));
-        PreoccupyRoomsRequestDto request5 = new PreoccupyRoomsRequestDto(List.of(
-            new PreoccupyRoomItemRequestDto(5L, "2024-03-05", "2024-03-08"),
-            new PreoccupyRoomItemRequestDto(6L, "2024-04-05", "2024-04-09"),
-            new PreoccupyRoomItemRequestDto(7L, "2024-04-05", "2024-04-09")
-        ));
+        PreoccupyRoomsRequestDto request1 = PreoccupyRoomsRequestDto.builder()
+            .rooms(
+                List.of(
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1001L)
+                        .startDate("2024-03-06")
+                        .endDate("2024-03-09")
+                        .build(),
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1002L)
+                        .startDate("2024-04-04")
+                        .endDate("2024-04-06")
+                        .build()
+                )
+            )
+            .build();
+
+        PreoccupyRoomsRequestDto request2 = PreoccupyRoomsRequestDto.builder()
+            .rooms(
+                List.of(
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1001L)
+                        .startDate("2024-03-05")
+                        .endDate("2024-03-08")
+                        .build(),
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1001L)
+                        .startDate("2024-03-05")
+                        .endDate("2024-03-08")
+                        .build()
+                )
+            )
+            .build();
+
+        PreoccupyRoomsRequestDto request3 = PreoccupyRoomsRequestDto.builder()
+            .rooms(
+                List.of(
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1001L)
+                        .startDate("2024-02-10")
+                        .endDate("2024-02-15")
+                        .build(),
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1003L)
+                        .startDate("2024-04-05")
+                        .endDate("2024-04-09")
+                        .build()
+                )
+            )
+            .build();
+
+        PreoccupyRoomsRequestDto request4 = PreoccupyRoomsRequestDto.builder()
+            .rooms(
+                List.of(
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1003L)
+                        .startDate("2024-04-04")
+                        .endDate("2024-04-08")
+                        .build()
+                )
+            )
+            .build();
+
+        PreoccupyRoomsRequestDto request5 = PreoccupyRoomsRequestDto.builder()
+            .rooms(
+                List.of(
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1001L)
+                        .startDate("2024-02-10")
+                        .endDate("2024-02-15")
+                        .build(),
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1003L)
+                        .startDate("2024-02-05")
+                        .endDate("2024-02-09")
+                        .build(),
+                    PreoccupyRoomItemRequestDto.builder()
+                        .roomCode(1002L)
+                        .startDate("2024-05-10")
+                        .endDate("2024-05-12")
+                        .build()
+                )
+            )
+            .build();
 
         executors.submit(() -> {
             StopWatch stopWatch = threadLocalStopWatch.get();
@@ -59,7 +285,7 @@ public class PreoccupyRoomsLockFacadeTest extends AbstractContainersSupport {
                 stopWatch.start();
                 preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(1L, request1);
             } catch (Exception e) {
-                System.out.println(e.getMessage());
+                log.error(e.getMessage());
             } finally {
                 stopWatch.stop();
                 log.info("{} ::: {} ms", "request1", stopWatch.getTotalTimeMillis());
@@ -74,7 +300,7 @@ public class PreoccupyRoomsLockFacadeTest extends AbstractContainersSupport {
                 stopWatch.start();
                 preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(2L, request2);
             } catch (Exception e) {
-                System.out.println(e.getMessage());
+                log.error(e.getMessage());
             } finally {
                 stopWatch.stop();
                 log.info("{} ::: {} ms", "request2", stopWatch.getTotalTimeMillis());
@@ -89,7 +315,7 @@ public class PreoccupyRoomsLockFacadeTest extends AbstractContainersSupport {
                 stopWatch.start();
                 preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(3L, request3);
             } catch (Exception e) {
-                System.out.println(e.getMessage());
+                log.error(e.getMessage());
             } finally {
                 stopWatch.stop();
                 log.info("{} ::: {} ms", "request3", stopWatch.getTotalTimeMillis());
@@ -104,7 +330,7 @@ public class PreoccupyRoomsLockFacadeTest extends AbstractContainersSupport {
                 stopWatch.start();
                 preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(4L, request4);
             } catch (Exception e) {
-                System.out.println(e.getMessage());
+                log.error(e.getMessage());
             } finally {
                 stopWatch.stop();
                 log.info("{} ::: {} ms", "request4", stopWatch.getTotalTimeMillis());
@@ -119,7 +345,7 @@ public class PreoccupyRoomsLockFacadeTest extends AbstractContainersSupport {
                 stopWatch.start();
                 preoccupyRoomsLockFacade.checkAvailableAndPreoccupy(5L, request5);
             } catch (Exception e) {
-                System.out.println(e.getMessage());
+                log.error(e.getMessage());
             } finally {
                 stopWatch.stop();
                 log.info("{} ::: {} ms", "request5", stopWatch.getTotalTimeMillis());


### PR DESCRIPTION
### 💡 Motivation
- 객실 종류를 기준으로 예약 가능 객실 수를 응답해주는 것으로 명세가 변경됨에 따라 객실 예약 가능 검증 및 선점 로직을 리팩토링 합니다.

### 📌 Changes
- 객실 선점 로직 관련 Request/Response DTO 클래스명 변경 및 수정
- RoomCode에 해당하는 모든 객실 식별자를 조회하는 쿼리 및 서비스 로직 추가
- PreoccupyRoomsService의 checkAvailable() 로직 리팩토링
- PreoccupyRoomsLockFacade에 변경된 로직을 반영해 수정
- '예약 선점 검증'과 '예약 결제 검증' Custom Exception 분리
   - PreoccupyNotAvailableException
   - ReserveNotAvailableException
- 예약 결제 검증 Exception 수정에 따른 ReservationService/ReservationLockFacade 예외 처리 로직 수정
- 객실 검증 및 선점 API 수정에 따른 기존 Test 코드 수정

### 🫱🏻‍🫲🏻 To Reviewers
- 객실에 대한 기능 명세가 변경됨에 따라 객실 예약 검증과 선점 API와 로직을 리팩토링 했습니다. 리뷰 부탁드립니다!!

This close #109 