### PR TITLE
feat: 즐겨찾기 기능 구현

### DIFF
--- a/src/docs/asciidoc/favorite/favorite-api.adoc
+++ b/src/docs/asciidoc/favorite/favorite-api.adoc
@@ -2,7 +2,7 @@ ifndef::snippets[]
 :snippets: build/generated-snippets
 endif::[]
 
-= Member REST API Docs
+= Favorite REST API Docs
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs

--- a/src/docs/asciidoc/favorite/favorite-api.adoc
+++ b/src/docs/asciidoc/favorite/favorite-api.adoc
@@ -1,0 +1,52 @@
+ifndef::snippets[]
+:snippets: build/generated-snippets
+endif::[]
+
+= Member REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+[[Register]]
+== 즐겨찾기 등록
+
+즐겨찾기 등록 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/favorite-rest-controller-docs-test/register/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/favorite-rest-controller-docs-test/register/http-response.adoc[]
+include::{snippets}/favorite-rest-controller-docs-test/register/response-fields.adoc[]
+
+[[Get-Favorites]]
+== 즐겨찾기 목록 조회
+
+즐겨찾기 목록 조회 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/favorite-rest-controller-docs-test/get-favorites/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/favorite-rest-controller-docs-test/get-favorites/http-response.adoc[]
+include::{snippets}/favorite-rest-controller-docs-test/get-favorites/response-fields.adoc[]
+
+[[Cancel]]
+== 즐겨찾기 취소
+
+즐겨찾기 취소 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/favorite-rest-controller-docs-test/cancel/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/favorite-rest-controller-docs-test/cancel/http-response.adoc[]
+include::{snippets}/favorite-rest-controller-docs-test/cancel/response-fields.adoc[]

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/controller/FavoriteRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/controller/FavoriteRestController.java
@@ -1,0 +1,32 @@
+package com.fc.shimpyo_be.domain.favorite.controller;
+
+import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
+import com.fc.shimpyo_be.domain.favorite.service.FavoriteService;
+import com.fc.shimpyo_be.global.common.ResponseDto;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/favorites")
+public class FavoriteRestController {
+
+    private final FavoriteService favoriteService;
+    private final SecurityUtil securityUtil;
+
+    @PostMapping("/{productId}")
+    public ResponseEntity<ResponseDto<FavoriteResponseDto>> register(@PathVariable long productId) {
+        log.debug("memberId: {}, productId: {}", securityUtil.getCurrentMemberId(), productId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.res(HttpStatus.CREATED,
+            favoriteService.register(securityUtil.getCurrentMemberId(), productId),
+            "성공적으로 즐겨찾기를 등록했습니다."));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/controller/FavoriteRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/controller/FavoriteRestController.java
@@ -1,13 +1,16 @@
 package com.fc.shimpyo_be.domain.favorite.controller;
 
 import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
+import com.fc.shimpyo_be.domain.favorite.dto.FavoritesResponseDto;
+import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
 import com.fc.shimpyo_be.domain.favorite.service.FavoriteService;
-import com.fc.shimpyo_be.domain.product.dto.response.ProductResponse;
+import com.fc.shimpyo_be.domain.product.util.model.PageableConstraint;
 import com.fc.shimpyo_be.global.common.ResponseDto;
 import com.fc.shimpyo_be.global.util.SecurityUtil;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,10 +38,12 @@ public class FavoriteRestController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDto<List<ProductResponse>>> getFavorites(){
+    public ResponseEntity<ResponseDto<FavoritesResponseDto>> getFavorites(
+        @PageableConstraint(Favorite.class) @PageableDefault(size = 10, page = 0) Pageable pageable) {
         log.debug("memberId: {}", securityUtil.getCurrentMemberId());
-        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.res(HttpStatus.OK, favoriteService.getFavorites(
-            securityUtil.getCurrentMemberId()), "성공적으로 즐겨찾기 목록을 조회했습니다."));
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDto.res(HttpStatus.OK, favoriteService.getFavorites(
+                securityUtil.getCurrentMemberId(), pageable), "성공적으로 즐겨찾기 목록을 조회했습니다."));
     }
 
     @DeleteMapping("/{productId}")

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/controller/FavoriteRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/controller/FavoriteRestController.java
@@ -2,12 +2,15 @@ package com.fc.shimpyo_be.domain.favorite.controller;
 
 import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
 import com.fc.shimpyo_be.domain.favorite.service.FavoriteService;
+import com.fc.shimpyo_be.domain.product.dto.response.ProductResponse;
 import com.fc.shimpyo_be.global.common.ResponseDto;
 import com.fc.shimpyo_be.global.util.SecurityUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +31,12 @@ public class FavoriteRestController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.res(HttpStatus.CREATED,
             favoriteService.register(securityUtil.getCurrentMemberId(), productId),
             "성공적으로 즐겨찾기를 등록했습니다."));
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<List<ProductResponse>>> getFavorites(){
+        log.debug("memberId: {}", securityUtil.getCurrentMemberId());
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.res(HttpStatus.OK, favoriteService.getFavorites(
+            securityUtil.getCurrentMemberId()), "성공적으로 즐겨찾기 목록을 조회했습니다."));
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/controller/FavoriteRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/controller/FavoriteRestController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,5 +39,13 @@ public class FavoriteRestController {
         log.debug("memberId: {}", securityUtil.getCurrentMemberId());
         return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.res(HttpStatus.OK, favoriteService.getFavorites(
             securityUtil.getCurrentMemberId()), "성공적으로 즐겨찾기 목록을 조회했습니다."));
+    }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ResponseDto<FavoriteResponseDto>> cancel(@PathVariable long productId) {
+        log.debug("memberId: {}, productId: {}", securityUtil.getCurrentMemberId(), productId);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.res(HttpStatus.OK,
+            favoriteService.delete(securityUtil.getCurrentMemberId(), productId),
+            "성공적으로 즐겨찾기를 취소했습니다."));
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/dto/FavoriteResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/dto/FavoriteResponseDto.java
@@ -1,0 +1,30 @@
+package com.fc.shimpyo_be.domain.favorite.dto;
+
+import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FavoriteResponseDto {
+
+    private Long favoriteId;
+    private Long memberId;
+    private Long productId;
+
+    @Builder
+    public FavoriteResponseDto(Long favoriteId, Long memberId, Long productId) {
+        this.favoriteId = favoriteId;
+        this.memberId = memberId;
+        this.productId = productId;
+    }
+
+    public static FavoriteResponseDto of(Favorite favorite) {
+        return FavoriteResponseDto.builder()
+            .favoriteId(favorite.getId())
+            .memberId(favorite.getMember().getId())
+            .productId(favorite.getProduct().getId())
+            .build();
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/dto/FavoritesResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/dto/FavoritesResponseDto.java
@@ -1,0 +1,23 @@
+package com.fc.shimpyo_be.domain.favorite.dto;
+
+import com.fc.shimpyo_be.domain.product.dto.response.ProductResponse;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FavoritesResponseDto {
+
+    private int pageCount;
+    private Boolean isLast;
+    private List<ProductResponse> products;
+
+    @Builder
+    public FavoritesResponseDto(int pageCount, Boolean isLast, List<ProductResponse> products) {
+        this.pageCount = pageCount;
+        this.isLast = isLast;
+        this.products = products;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/exception/FavoriteAlreadyRegisterException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/exception/FavoriteAlreadyRegisterException.java
@@ -1,0 +1,11 @@
+package com.fc.shimpyo_be.domain.favorite.exception;
+
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+
+public class FavoriteAlreadyRegisterException extends ApplicationException {
+
+    public FavoriteAlreadyRegisterException() {
+        super(ErrorCode.FAVORITE_ALREADY_REGISTER);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/exception/FavoriteNotFoundException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/exception/FavoriteNotFoundException.java
@@ -1,0 +1,11 @@
+package com.fc.shimpyo_be.domain.favorite.exception;
+
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+
+public class FavoriteNotFoundException extends ApplicationException {
+
+    public FavoriteNotFoundException() {
+        super(ErrorCode.FAVORITE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteCustomRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteCustomRepository.java
@@ -1,0 +1,10 @@
+package com.fc.shimpyo_be.domain.favorite.repository;
+
+import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FavoriteCustomRepository {
+
+    Page<Favorite> findAllByMemberId(long memberId, Pageable pageable);
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteCustomRepositoryImpl.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteCustomRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.fc.shimpyo_be.domain.favorite.repository;
+
+import static com.fc.shimpyo_be.domain.favorite.entity.QFavorite.favorite;
+import static com.fc.shimpyo_be.domain.member.entity.QMember.member;
+import static com.fc.shimpyo_be.domain.product.entity.QProduct.product;
+
+import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
+import com.fc.shimpyo_be.global.util.QueryDslUtil;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.LinkedList;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class FavoriteCustomRepositoryImpl implements FavoriteCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    FavoriteCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.queryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Page<Favorite> findAllByMemberId(long memberId, Pageable pageable) {
+        JPAQuery<Favorite> query = queryFactory
+            .selectDistinct(favorite)
+            .from(favorite)
+            .leftJoin(favorite.member, member)
+            .leftJoin(favorite.product, product)
+            .where(member.id.eq(memberId))
+            .offset(pageable.getOffset())
+            .orderBy(getAllOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new))
+            .limit(pageable.getPageSize());
+        JPAQuery<Favorite> countQuery = queryFactory
+            .selectDistinct(favorite)
+            .from(favorite)
+            .leftJoin(favorite.member, member)
+            .leftJoin(favorite.product, product)
+            .where(member.id.eq(memberId));
+        List<Favorite> content = query.fetch();
+        return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
+    }
+
+    private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> ORDERS = new LinkedList<>();
+        ORDERS.add(QueryDslUtil.getSortedColumn(Order.DESC, favorite, "id"));
+        return ORDERS;
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteRepository.java
@@ -3,13 +3,11 @@ package com.fc.shimpyo_be.domain.favorite.repository;
 import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
 import com.fc.shimpyo_be.domain.member.entity.Member;
 import com.fc.shimpyo_be.domain.product.entity.Product;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+public interface FavoriteRepository extends JpaRepository<Favorite, Long>,
+    FavoriteCustomRepository {
 
     Optional<Favorite> findByMemberAndProduct(Member member, Product product);
-
-    List<Favorite> findAllByMember(Member member);
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteRepository.java
@@ -3,10 +3,13 @@ package com.fc.shimpyo_be.domain.favorite.repository;
 import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
 import com.fc.shimpyo_be.domain.member.entity.Member;
 import com.fc.shimpyo_be.domain.product.entity.Product;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     Optional<Favorite> findByMemberAndProduct(Member member, Product product);
+
+    List<Favorite> findByMember(Member member);
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteRepository.java
@@ -11,5 +11,5 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     Optional<Favorite> findByMemberAndProduct(Member member, Product product);
 
-    List<Favorite> findByMember(Member member);
+    List<Favorite> findAllByMember(Member member);
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/repository/FavoriteRepository.java
@@ -1,8 +1,12 @@
 package com.fc.shimpyo_be.domain.favorite.repository;
 
 import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.product.entity.Product;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
+    Optional<Favorite> findByMemberAndProduct(Member member, Product product);
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
@@ -43,7 +43,7 @@ public class FavoriteService {
     public List<ProductResponse> getFavorites(long memberId) {
         List<ProductResponse> productResponses = new ArrayList<>();
         Member member = memberService.getMemberById(memberId);
-        List<Favorite> favorites = favoriteRepository.findByMember(member);
+        List<Favorite> favorites = favoriteRepository.findAllByMember(member);
         for (Favorite favorite : favorites) {
             productResponses.add(ProductMapper.toProductResponse(favorite.getProduct()));
         }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,37 @@
+package com.fc.shimpyo_be.domain.favorite.service;
+
+import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
+import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
+import com.fc.shimpyo_be.domain.favorite.exception.FavoriteAlreadyRegisterException;
+import com.fc.shimpyo_be.domain.favorite.repository.FavoriteRepository;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
+import com.fc.shimpyo_be.domain.product.entity.Product;
+import com.fc.shimpyo_be.domain.product.exception.ProductNotFoundException;
+import com.fc.shimpyo_be.domain.product.repository.ProductRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final MemberService memberService;
+    private final ProductRepository productRepository;
+
+    public FavoriteResponseDto register(long memberId, long productId) {
+        Member member = memberService.getMemberById(memberId);
+        Product product = productRepository.findById(productId).orElseThrow(
+            ProductNotFoundException::new);
+        Optional<Favorite> favorite = favoriteRepository.findByMemberAndProduct(member, product);
+        if (favorite.isEmpty()) {
+            throw new FavoriteAlreadyRegisterException();
+        }
+        return FavoriteResponseDto.of(favoriteRepository.save(Favorite.builder()
+            .member(member)
+            .product(product)
+            .build()));
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
@@ -3,6 +3,8 @@ package com.fc.shimpyo_be.domain.favorite.service;
 import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
 import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
 import com.fc.shimpyo_be.domain.favorite.exception.FavoriteAlreadyRegisterException;
+import com.fc.shimpyo_be.domain.favorite.exception.FavoriteNotFoundException;
+import com.fc.shimpyo_be.domain.favorite.exception.FavoriteNotRegisteredException;
 import com.fc.shimpyo_be.domain.favorite.repository.FavoriteRepository;
 import com.fc.shimpyo_be.domain.member.entity.Member;
 import com.fc.shimpyo_be.domain.member.service.MemberService;
@@ -47,5 +49,16 @@ public class FavoriteService {
             productResponses.add(ProductMapper.toProductResponse(favorite.getProduct()));
         }
         return productResponses;
+    }
+
+    public FavoriteResponseDto deleteFavorite(long memberId, long productId) {
+        Member member = memberService.getMemberById(memberId);
+        Product product = productRepository.findById(productId).orElseThrow(
+            ProductNotFoundException::new);
+        Favorite favorite = favoriteRepository.findByMemberAndProduct(member, product)
+            .orElseThrow(FavoriteNotFoundException::new);
+        FavoriteResponseDto favoriteResponseDto = FavoriteResponseDto.of(favorite);
+        favoriteRepository.delete(favorite);
+        return favoriteResponseDto;
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
@@ -1,6 +1,7 @@
 package com.fc.shimpyo_be.domain.favorite.service;
 
 import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
+import com.fc.shimpyo_be.domain.favorite.dto.FavoritesResponseDto;
 import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
 import com.fc.shimpyo_be.domain.favorite.exception.FavoriteAlreadyRegisterException;
 import com.fc.shimpyo_be.domain.favorite.exception.FavoriteNotFoundException;
@@ -16,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -40,14 +43,18 @@ public class FavoriteService {
             .build()));
     }
 
-    public List<ProductResponse> getFavorites(long memberId) {
+    public FavoritesResponseDto getFavorites(long memberId, Pageable pageable) {
         List<ProductResponse> productResponses = new ArrayList<>();
         Member member = memberService.getMemberById(memberId);
-        List<Favorite> favorites = favoriteRepository.findAllByMember(member);
+        Page<Favorite> favorites = favoriteRepository.findAllByMemberId(member.getId(), pageable);
         for (Favorite favorite : favorites) {
             productResponses.add(ProductMapper.toProductResponse(favorite.getProduct()));
         }
-        return productResponses;
+        return FavoritesResponseDto.builder()
+            .pageCount(favorites.getTotalPages())
+            .isLast(favorites.isLast())
+            .products(productResponses)
+            .build();
     }
 
     public FavoriteResponseDto delete(long memberId, long productId) {

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
@@ -31,7 +31,7 @@ public class FavoriteService {
         Product product = productRepository.findById(productId).orElseThrow(
             ProductNotFoundException::new);
         Optional<Favorite> favorite = favoriteRepository.findByMemberAndProduct(member, product);
-        if (favorite.isEmpty()) {
+        if (favorite.isPresent()) {
             throw new FavoriteAlreadyRegisterException();
         }
         return FavoriteResponseDto.of(favoriteRepository.save(Favorite.builder()

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
@@ -6,9 +6,13 @@ import com.fc.shimpyo_be.domain.favorite.exception.FavoriteAlreadyRegisterExcept
 import com.fc.shimpyo_be.domain.favorite.repository.FavoriteRepository;
 import com.fc.shimpyo_be.domain.member.entity.Member;
 import com.fc.shimpyo_be.domain.member.service.MemberService;
+import com.fc.shimpyo_be.domain.product.dto.response.ProductResponse;
 import com.fc.shimpyo_be.domain.product.entity.Product;
 import com.fc.shimpyo_be.domain.product.exception.ProductNotFoundException;
 import com.fc.shimpyo_be.domain.product.repository.ProductRepository;
+import com.fc.shimpyo_be.domain.product.util.ProductMapper;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,5 +37,15 @@ public class FavoriteService {
             .member(member)
             .product(product)
             .build()));
+    }
+
+    public List<ProductResponse> getFavorites(long memberId) {
+        List<ProductResponse> productResponses = new ArrayList<>();
+        Member member = memberService.getMemberById(memberId);
+        List<Favorite> favorites = favoriteRepository.findByMember(member);
+        for (Favorite favorite : favorites) {
+            productResponses.add(ProductMapper.toProductResponse(favorite.getProduct()));
+        }
+        return productResponses;
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
@@ -4,7 +4,6 @@ import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
 import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
 import com.fc.shimpyo_be.domain.favorite.exception.FavoriteAlreadyRegisterException;
 import com.fc.shimpyo_be.domain.favorite.exception.FavoriteNotFoundException;
-import com.fc.shimpyo_be.domain.favorite.exception.FavoriteNotRegisteredException;
 import com.fc.shimpyo_be.domain.favorite.repository.FavoriteRepository;
 import com.fc.shimpyo_be.domain.member.entity.Member;
 import com.fc.shimpyo_be.domain.member.service.MemberService;
@@ -51,7 +50,7 @@ public class FavoriteService {
         return productResponses;
     }
 
-    public FavoriteResponseDto deleteFavorite(long memberId, long productId) {
+    public FavoriteResponseDto delete(long memberId, long productId) {
         Member member = memberService.getMemberById(memberId);
         Product product = productRepository.findById(productId).orElseThrow(
             ProductNotFoundException::new);

--- a/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
@@ -47,7 +47,7 @@ public enum ErrorCode {
 
     // 즐겨찾기
     FAVORITE_ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "이미 즐겨찾기에 등록한 숙소입니다."),
-    FAVORITE_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "즐겨찾기 하지 않았습니다.");
+    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "즐겨찾기 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String simpleMessage;

--- a/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
@@ -42,8 +42,12 @@ public enum ErrorCode {
     HTTP_CLIENT_CONNECTION_ERROR(HttpStatus.UNAUTHORIZED, "외부 API 연결에 실패했습니다."),
     OPEN_API_ERROR(HttpStatus.NOT_FOUND, "오픈 API에서 데이터를 불러오는데 실패했습니다."),
 
-    //Common
-    INVALID_DATE(HttpStatus.BAD_REQUEST,"잘못된 날짜 데이터입니다.");
+    // Common
+    INVALID_DATE(HttpStatus.BAD_REQUEST,"잘못된 날짜 데이터입니다."),
+
+    // 즐겨찾기
+    FAVORITE_ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "이미 즐겨찾기에 등록한 숙소입니다."),
+    FAVORITE_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "즐겨찾기 하지 않았습니다.");
 
     private final HttpStatus httpStatus;
     private final String simpleMessage;

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/docs/FavoriteRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/docs/FavoriteRestControllerDocsTest.java
@@ -1,0 +1,163 @@
+package com.fc.shimpyo_be.domain.favorite.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fc.shimpyo_be.config.RestDocsSupport;
+import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
+import com.fc.shimpyo_be.domain.favorite.dto.FavoritesResponseDto;
+import com.fc.shimpyo_be.domain.favorite.service.FavoriteService;
+import com.fc.shimpyo_be.domain.product.dto.response.ProductResponse;
+import com.fc.shimpyo_be.domain.product.entity.Category;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+public class FavoriteRestControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private FavoriteService favoriteService;
+
+    @MockBean
+    SecurityUtil securityUtil;
+
+    @Test
+    @DisplayName("register()은 즐겨찾기를 등록할 수 있다.")
+    @WithMockUser(roles = "USER")
+    void register() throws Exception {
+        // given
+        FavoriteResponseDto favoriteResponseDto = FavoriteResponseDto.builder()
+            .favoriteId(1L)
+            .memberId(1L)
+            .productId(1L)
+            .build();
+
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        given(favoriteService.register(any(Long.TYPE), any(Long.TYPE))).willReturn(
+            favoriteResponseDto);
+
+        // when then
+        mockMvc.perform(post("/api/favorites/{productId}", 1L))
+            .andExpect(status().isCreated())
+            .andDo(restDoc.document(
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.favoriteId").type(JsonFieldType.NUMBER)
+                        .description("즐겨찾기 식별자"),
+                    fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
+                    fieldWithPath("data.productId").type(JsonFieldType.NUMBER).description("숙소 식별자")
+                ))
+            );
+    }
+
+
+    @Test
+    @DisplayName("getFavorites()은 즐겨찾기 목록을 조회할 수 있다.")
+    @WithMockUser(roles = "USER")
+    void getFavorites() throws Exception {
+        // given
+        FavoritesResponseDto favoritesResponseDto = FavoritesResponseDto.builder()
+            .pageCount(10)
+            .isLast(true)
+            .products(List.of(ProductResponse.builder()
+                .productId(1L)
+                .productName("OO 호텔")
+                .category(Category.TOURIST_HOTEL.getName())
+                .address("서울시 강남구 OO로 000-000 상세주소")
+                .favorites(true)
+                .image(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .starAvg(5F)
+                .price(95000L)
+                .capacity(4L)
+                .build()))
+            .build();
+
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        given(favoriteService.getFavorites(any(Long.TYPE), any(Pageable.class)))
+            .willReturn(favoritesResponseDto);
+
+        // when then
+        mockMvc.perform(get("/api/favorites")
+                .queryParam("page", "0")
+                .queryParam("size", "10"))
+            .andExpect(status().isOk())
+            .andDo(restDoc.document(
+                queryParameters(parameterWithName("page").optional().description("페이지 인덱스"),
+                    parameterWithName("size").optional().description("페이지 사이즈")
+                ),
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.pageCount").type(JsonFieldType.NUMBER)
+                        .description("총 페이지 개수"),
+                    fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN)
+                        .description("마지막 페이지 여부"),
+                    fieldWithPath("data.products").type(JsonFieldType.ARRAY)
+                        .description("숙소 응답 데이터 배열"),
+                    fieldWithPath("data.products[].productId").type(
+                            JsonFieldType.NUMBER)
+                        .description("숙소 아이디"),
+                    fieldWithPath("data.products[].category").type(JsonFieldType.STRING)
+                        .description("숙소 카테고리(호텔, 모텔, 풀빌라, 펜션)"),
+                    fieldWithPath("data.products[].address").type(JsonFieldType.STRING)
+                        .description("숙소 주소"),
+                    fieldWithPath("data.products[].productName").type(
+                            JsonFieldType.STRING)
+                        .description("숙소 이름"),
+                    fieldWithPath("data.products[].favorites").type(
+                            JsonFieldType.BOOLEAN)
+                        .description("즐겨찾기"),
+                    fieldWithPath("data.products[].starAvg").type(JsonFieldType.NUMBER)
+                        .description("숙소 평점"),
+                    fieldWithPath("data.products[].image").type(JsonFieldType.STRING)
+                        .description("숙소 썸네일 이미지"),
+                    fieldWithPath("data.products[].price").type(JsonFieldType.NUMBER)
+                        .description("숙소 내 방 최저 가격"),
+                    fieldWithPath("data.products[].capacity").type(JsonFieldType.NUMBER)
+                        .description("최대 인원")
+                ))
+            );
+    }
+
+    @Test
+    @DisplayName("cancel은 즐겨찾기를 취소할 수 있다.")
+    @WithMockUser(roles = "USER")
+    void cancel() throws Exception {
+        // given
+        FavoriteResponseDto favoriteResponseDto = FavoriteResponseDto.builder()
+            .favoriteId(1L)
+            .memberId(1L)
+            .productId(1L)
+            .build();
+
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        given(favoriteService.delete(any(Long.TYPE), any(Long.TYPE))).willReturn(
+            favoriteResponseDto);
+
+        // when then
+        mockMvc.perform(delete("/api/favorites/{productId}", 1L))
+            .andExpect(status().isOk())
+            .andDo(restDoc.document(
+                responseFields(responseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.favoriteId").type(JsonFieldType.NUMBER)
+                        .description("즐겨찾기 식별자"),
+                    fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("회원 식별자"),
+                    fieldWithPath("data.productId").type(JsonFieldType.NUMBER).description("숙소 식별자")
+                ))
+            );
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/controller/FavoriteRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/controller/FavoriteRestControllerTest.java
@@ -1,0 +1,178 @@
+package com.fc.shimpyo_be.domain.favorite.unit.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.shimpyo_be.config.AbstractContainersSupport;
+import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
+import com.fc.shimpyo_be.domain.favorite.dto.FavoritesResponseDto;
+import com.fc.shimpyo_be.domain.favorite.service.FavoriteService;
+import com.fc.shimpyo_be.domain.product.dto.response.ProductResponse;
+import com.fc.shimpyo_be.domain.product.entity.Category;
+import com.fc.shimpyo_be.global.util.SecurityUtil;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class FavoriteRestControllerTest extends AbstractContainersSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    WebApplicationContext context;
+
+    @MockBean
+    FavoriteService favoriteService;
+
+    @MockBean
+    SecurityUtil securityUtil;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(this.context)
+            .apply(springSecurity())
+            .build();
+    }
+
+    @Nested
+    @DisplayName("register()은")
+    class Context_register {
+
+        @Test
+        @DisplayName("즐겨찾기를 등록할 수 있다.")
+        @WithMockUser(roles = "USER")
+        void _willSuccess() throws Exception {
+            // given
+            FavoriteResponseDto favoriteResponseDto = FavoriteResponseDto.builder()
+                .favoriteId(1L)
+                .memberId(1L)
+                .productId(1L)
+                .build();
+
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+            given(favoriteService.register(any(Long.TYPE), any(Long.TYPE))).willReturn(
+                favoriteResponseDto);
+
+            // when then
+            mockMvc.perform(post("/api/favorites/{productId}", 1L))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").isNumber())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.favoriteId").isNumber())
+                .andExpect(jsonPath("$.data.memberId").isNumber())
+                .andExpect(jsonPath("$.data.productId").isNumber())
+                .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("getFavorites()은")
+    class Context_getFavorites {
+
+        @Test
+        @DisplayName("즐겨찾기 목록을 조회할 수 있다.")
+        @WithMockUser(roles = "USER")
+        void _willSuccess() throws Exception {
+            // given
+            FavoritesResponseDto favoritesResponseDto = FavoritesResponseDto.builder()
+                .pageCount(10)
+                .isLast(true)
+                .products(List.of(ProductResponse.builder()
+                    .productId(1L)
+                    .productName("OO 호텔")
+                    .category(Category.TOURIST_HOTEL.getName())
+                    .address("서울시 강남구 OO로 000-000 상세주소")
+                    .favorites(true)
+                    .image(
+                        "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                    .starAvg(5F)
+                    .price(95000L)
+                    .capacity(4L)
+                    .build()))
+                .build();
+
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+            given(favoriteService.getFavorites(any(Long.TYPE), any(Pageable.class))).willReturn(
+                favoritesResponseDto);
+
+            // when then
+            mockMvc.perform(get("/api/favorites")
+                    .queryParam("page", "0")
+                    .queryParam("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").isNumber())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.pageCount").isNumber())
+                .andExpect(jsonPath("$.data.isLast").isBoolean())
+                .andExpect(jsonPath("$.data.products[0].productId").isNumber())
+                .andExpect(jsonPath("$.data.products[0].productName").isString())
+                .andExpect(jsonPath("$.data.products[0].category").isString())
+                .andExpect(jsonPath("$.data.products[0].address").isString())
+                .andExpect(jsonPath("$.data.products[0].favorites").isBoolean())
+                .andExpect(jsonPath("$.data.products[0].image").isString())
+                .andExpect(jsonPath("$.data.products[0].starAvg").isNumber())
+                .andExpect(jsonPath("$.data.products[0].price").isNumber())
+                .andExpect(jsonPath("$.data.products[0].capacity").isNumber())
+                .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("cancel()은")
+    class Context_cancel {
+
+        @Test
+        @DisplayName("즐겨찾기를 취소할 수 있다.")
+        @WithMockUser(roles = "USER")
+        void _willSuccess() throws Exception {
+            // given
+            FavoriteResponseDto favoriteResponseDto = FavoriteResponseDto.builder()
+                .favoriteId(1L)
+                .memberId(1L)
+                .productId(1L)
+                .build();
+
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+            given(favoriteService.delete(any(Long.TYPE), any(Long.TYPE))).willReturn(
+                favoriteResponseDto);
+
+            // when then
+            mockMvc.perform(delete("/api/favorites/{productId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").isNumber())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.favoriteId").isNumber())
+                .andExpect(jsonPath("$.data.memberId").isNumber())
+                .andExpect(jsonPath("$.data.productId").isNumber())
+                .andDo(print());
+        }
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/repository/FavoriteRepositoryTest.java
@@ -1,0 +1,178 @@
+package com.fc.shimpyo_be.domain.favorite.unit.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fc.shimpyo_be.config.TestJpaConfig;
+import com.fc.shimpyo_be.config.TestQuerydslConfig;
+import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
+import com.fc.shimpyo_be.domain.favorite.repository.FavoriteRepository;
+import com.fc.shimpyo_be.domain.member.entity.Authority;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import com.fc.shimpyo_be.domain.product.entity.Address;
+import com.fc.shimpyo_be.domain.product.entity.Amenity;
+import com.fc.shimpyo_be.domain.product.entity.Category;
+import com.fc.shimpyo_be.domain.product.entity.Product;
+import com.fc.shimpyo_be.domain.product.entity.ProductOption;
+import com.fc.shimpyo_be.domain.product.repository.ProductRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({TestJpaConfig.class, TestQuerydslConfig.class})
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+public class FavoriteRepositoryTest {
+
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    public void reset() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        favoriteRepository.deleteAll();
+        memberRepository.deleteAll();
+        productRepository.deleteAll();
+        entityManager.createNativeQuery("TRUNCATE TABLE favorite").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE member").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE product").executeUpdate();
+        entityManager
+            .createNativeQuery("ALTER TABLE favorite ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager
+            .createNativeQuery("ALTER TABLE member ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager
+            .createNativeQuery("ALTER TABLE product ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private Member saveMember() {
+        Member member = Member.builder()
+            .email("test@mail.com")
+            .name("test")
+            .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+            .photoUrl(
+                "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+            .authority(Authority.ROLE_USER)
+            .build();
+        return memberRepository.save(member);
+    }
+
+    private Product saveProduct() {
+        Product product = Product.builder()
+            .id(1L)
+            .name("OO 호텔")
+            .address(Address.builder()
+                .address("서울시 강남구 OO로 000-000")
+                .detailAddress("상세주소")
+                .mapX(1.0)
+                .mapY(1.0)
+                .build())
+            .thumbnail(
+                "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+            .category(Category.TOURIST_HOTEL)
+            .starAvg(5)
+            .description("호텔입니다.")
+            .rooms(new ArrayList<>())
+            .productOption(ProductOption.builder()
+                .cooking(false)
+                .parking(false)
+                .pickup(false)
+                .foodPlace("")
+                .infoCenter("000-0000-0000")
+                .build())
+            .amenity(Amenity.builder()
+                .barbecue(false)
+                .beauty(false)
+                .beverage(false)
+                .bicycle(false)
+                .campfire(false)
+                .karaoke(false)
+                .publicBath(false)
+                .publicPc(false)
+                .sauna(false)
+                .seminar(false)
+                .sports(false)
+                .fitness(false)
+                .build())
+            .build();
+        return productRepository.save(product);
+    }
+
+    private void saveFavorite(Member member, Product product) {
+        Favorite favorite = Favorite.builder()
+            .member(member)
+            .product(product)
+            .build();
+        favoriteRepository.save(favorite);
+    }
+
+    @Nested
+    @DisplayName("findByMemberAndProduct()는")
+    class Context_findByMemberAndProduct {
+
+        @Test
+        @DisplayName("회원과 숙소로 즐겨찾기 정보를 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            Member member = saveMember();
+            Product product = saveProduct();
+            saveFavorite(member, product);
+
+            // when
+            Optional<Favorite> result = favoriteRepository.findByMemberAndProduct(member, product);
+
+            // then
+            assertThat(result.isPresent()).isTrue();
+            assertThat(result.get().getId()).isNotNull();
+            assertThat(result.get().getMember().getId()).isEqualTo(member.getId());
+            assertThat(result.get().getProduct().getId()).isEqualTo(product.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByMember()는")
+    class Context_findAllByMember {
+
+        @Test
+        @DisplayName("회원으로 즐겨찾기 정보 목록을 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            Member member = saveMember();
+            Product product = saveProduct();
+            saveFavorite(member, product);
+
+            // when
+            List<Favorite> result = favoriteRepository.findAllByMember(member);
+
+            // then
+            assertThat(result.isEmpty()).isFalse();
+            assertThat(result.get(0).getId()).isNotNull();
+            assertThat(result.get(0).getMember().getId()).isEqualTo(member.getId());
+            assertThat(result.get(0).getProduct().getId()).isEqualTo(product.getId());
+        }
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/repository/FavoriteRepositoryTest.java
@@ -18,7 +18,6 @@ import com.fc.shimpyo_be.domain.product.repository.ProductRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +28,8 @@ import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @DataJpaTest
 @Import({TestJpaConfig.class, TestQuerydslConfig.class})
@@ -154,8 +155,8 @@ public class FavoriteRepositoryTest {
     }
 
     @Nested
-    @DisplayName("findAllByMember()는")
-    class Context_findAllByMember {
+    @DisplayName("findAllByMemberId()는")
+    class Context_findAllByMemberId {
 
         @Test
         @DisplayName("회원으로 즐겨찾기 정보 목록을 조회할 수 있다.")
@@ -164,15 +165,19 @@ public class FavoriteRepositoryTest {
             Member member = saveMember();
             Product product = saveProduct();
             saveFavorite(member, product);
+            Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
 
             // when
-            List<Favorite> result = favoriteRepository.findAllByMember(member);
+            Page<Favorite> result = favoriteRepository.findAllByMemberId(member.getId(), pageable);
 
             // then
             assertThat(result.isEmpty()).isFalse();
-            assertThat(result.get(0).getId()).isNotNull();
-            assertThat(result.get(0).getMember().getId()).isEqualTo(member.getId());
-            assertThat(result.get(0).getProduct().getId()).isEqualTo(product.getId());
+            assertThat(result.getTotalPages()).isEqualTo(1);
+            assertThat(result.isLast()).isTrue();
+            assertThat(result.get().toList().get(0).getId()).isNotNull();
+            assertThat(result.get().toList().get(0).getMember().getId()).isEqualTo(member.getId());
+            assertThat(result.get().toList().get(0).getProduct().getId()).isEqualTo(
+                product.getId());
         }
     }
 }

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/service/FavoriteServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/service/FavoriteServiceTest.java
@@ -1,0 +1,290 @@
+package com.fc.shimpyo_be.domain.favorite.unit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
+import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
+import com.fc.shimpyo_be.domain.favorite.repository.FavoriteRepository;
+import com.fc.shimpyo_be.domain.favorite.service.FavoriteService;
+import com.fc.shimpyo_be.domain.member.entity.Authority;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
+import com.fc.shimpyo_be.domain.product.dto.response.ProductResponse;
+import com.fc.shimpyo_be.domain.product.entity.Address;
+import com.fc.shimpyo_be.domain.product.entity.Amenity;
+import com.fc.shimpyo_be.domain.product.entity.Category;
+import com.fc.shimpyo_be.domain.product.entity.Product;
+import com.fc.shimpyo_be.domain.product.entity.ProductOption;
+import com.fc.shimpyo_be.domain.product.repository.ProductRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class FavoriteServiceTest {
+
+    @InjectMocks
+    private FavoriteService favoriteService;
+
+    @Mock
+    private FavoriteRepository favoriteRepository;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Nested
+    @DisplayName("register()은")
+    class Context_register {
+
+        @Test
+        @DisplayName("즐겨찾기를 등록할 수 있다.")
+        void _willSuccess() {
+            // given
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_USER)
+                .build();
+            Product product = Product.builder()
+                .id(1L)
+                .name("OO 호텔")
+                .address(Address.builder()
+                    .address("서울시 강남구 OO로 000-000")
+                    .detailAddress("상세주소")
+                    .mapX(1.0)
+                    .mapY(1.0)
+                    .build())
+                .thumbnail(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .category(Category.TOURIST_HOTEL)
+                .starAvg(5)
+                .description("호텔입니다.")
+                .rooms(new ArrayList<>())
+                .productOption(ProductOption.builder()
+                    .cooking(false)
+                    .parking(false)
+                    .pickup(false)
+                    .foodPlace("")
+                    .infoCenter("000-0000-0000")
+                    .build())
+                .amenity(Amenity.builder()
+                    .barbecue(false)
+                    .beauty(false)
+                    .beverage(false)
+                    .bicycle(false)
+                    .campfire(false)
+                    .karaoke(false)
+                    .publicBath(false)
+                    .publicPc(false)
+                    .sauna(false)
+                    .seminar(false)
+                    .sports(false)
+                    .fitness(false)
+                    .build())
+                .build();
+            Favorite favorite = Favorite.builder()
+                .id(1L)
+                .member(member)
+                .product(product)
+                .build();
+
+            given(memberService.getMemberById(any(Long.TYPE))).willReturn(member);
+            given(productRepository.findById(any(Long.TYPE))).willReturn(Optional.of(product));
+            given(favoriteRepository.findByMemberAndProduct(any(Member.class), any(Product.class)))
+                .willReturn(Optional.empty());
+            given(favoriteRepository.save(any(Favorite.class))).willReturn(favorite);
+
+            // when
+            FavoriteResponseDto result = favoriteService.register(1L, 1L);
+
+            // then
+            assertNotNull(result);
+            assertThat(result).extracting("favoriteId", "memberId", "productId")
+                .containsExactly(1L, 1L, 1L);
+
+            verify(memberService, times(1)).getMemberById(any(Long.TYPE));
+            verify(productRepository, times(1)).findById(any(Long.TYPE));
+            verify(favoriteRepository, times(1))
+                .findByMemberAndProduct(any(Member.class), any(Product.class));
+            verify(favoriteRepository, times(1)).save(any(Favorite.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getFavorites()은")
+    class Context_getFavorites {
+
+        @Test
+        @DisplayName("즐겨찾기 목록을 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_USER)
+                .build();
+            Product product = Product.builder()
+                .id(1L)
+                .name("OO 호텔")
+                .address(Address.builder()
+                    .address("서울시 강남구 OO로 000-000")
+                    .detailAddress("상세주소")
+                    .mapX(1.0)
+                    .mapY(1.0)
+                    .build())
+                .thumbnail(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .category(Category.TOURIST_HOTEL)
+                .starAvg(5)
+                .description("호텔입니다.")
+                .rooms(new ArrayList<>())
+                .productOption(ProductOption.builder()
+                    .cooking(false)
+                    .parking(false)
+                    .pickup(false)
+                    .foodPlace("")
+                    .infoCenter("000-0000-0000")
+                    .build())
+                .amenity(Amenity.builder()
+                    .barbecue(false)
+                    .beauty(false)
+                    .beverage(false)
+                    .bicycle(false)
+                    .campfire(false)
+                    .karaoke(false)
+                    .publicBath(false)
+                    .publicPc(false)
+                    .sauna(false)
+                    .seminar(false)
+                    .sports(false)
+                    .fitness(false)
+                    .build())
+                .build();
+            Favorite favorite = Favorite.builder()
+                .id(1L)
+                .member(member)
+                .product(product)
+                .build();
+
+            given(memberService.getMemberById(any(Long.TYPE))).willReturn(member);
+            given(favoriteRepository.findByMember(any(Member.class))).willReturn(List.of(favorite));
+
+            // when
+            List<ProductResponse> result = favoriteService.getFavorites(1L);
+
+            // then
+            assertNotNull(result);
+
+            verify(memberService, times(1)).getMemberById(any(Long.TYPE));
+            verify(favoriteRepository, times(1)).findByMember(any(Member.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("delete()은")
+    class Context_delete {
+
+        @Test
+        @DisplayName("즐겨찾기를 취소할 수 있다.")
+        void _willSuccess() {
+            // given
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .name("test")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .photoUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_USER)
+                .build();
+            Product product = Product.builder()
+                .id(1L)
+                .name("OO 호텔")
+                .address(Address.builder()
+                    .address("서울시 강남구 OO로 000-000")
+                    .detailAddress("상세주소")
+                    .mapX(1.0)
+                    .mapY(1.0)
+                    .build())
+                .thumbnail(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .category(Category.TOURIST_HOTEL)
+                .starAvg(5)
+                .description("호텔입니다.")
+                .rooms(new ArrayList<>())
+                .productOption(ProductOption.builder()
+                    .cooking(false)
+                    .parking(false)
+                    .pickup(false)
+                    .foodPlace("")
+                    .infoCenter("000-0000-0000")
+                    .build())
+                .amenity(Amenity.builder()
+                    .barbecue(false)
+                    .beauty(false)
+                    .beverage(false)
+                    .bicycle(false)
+                    .campfire(false)
+                    .karaoke(false)
+                    .publicBath(false)
+                    .publicPc(false)
+                    .sauna(false)
+                    .seminar(false)
+                    .sports(false)
+                    .fitness(false)
+                    .build())
+                .build();
+            Favorite favorite = Favorite.builder()
+                .id(1L)
+                .member(member)
+                .product(product)
+                .build();
+
+            given(memberService.getMemberById(any(Long.TYPE))).willReturn(member);
+            given(productRepository.findById(any(Long.TYPE))).willReturn(Optional.of(product));
+            given(favoriteRepository.findByMemberAndProduct(any(Member.class), any(Product.class)))
+                .willReturn(Optional.of(favorite));
+            doNothing().when(favoriteRepository).delete(any(Favorite.class));
+
+            // when
+            FavoriteResponseDto result = favoriteService.delete(1L, 1L);
+
+            // then
+            assertNotNull(result);
+            assertThat(result).extracting("favoriteId", "memberId", "productId")
+                .containsExactly(1L, 1L, 1L);
+
+            verify(memberService, times(1)).getMemberById(any(Long.TYPE));
+            verify(productRepository, times(1)).findById(any(Long.TYPE));
+            verify(favoriteRepository, times(1))
+                .findByMemberAndProduct(any(Member.class), any(Product.class));
+            verify(favoriteRepository, times(1)).delete(any(Favorite.class));
+        }
+    }
+}

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/service/FavoriteServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/service/FavoriteServiceTest.java
@@ -193,7 +193,7 @@ public class FavoriteServiceTest {
                 .build();
 
             given(memberService.getMemberById(any(Long.TYPE))).willReturn(member);
-            given(favoriteRepository.findByMember(any(Member.class))).willReturn(List.of(favorite));
+            given(favoriteRepository.findAllByMember(any(Member.class))).willReturn(List.of(favorite));
 
             // when
             List<ProductResponse> result = favoriteService.getFavorites(1L);
@@ -202,7 +202,7 @@ public class FavoriteServiceTest {
             assertNotNull(result);
 
             verify(memberService, times(1)).getMemberById(any(Long.TYPE));
-            verify(favoriteRepository, times(1)).findByMember(any(Member.class));
+            verify(favoriteRepository, times(1)).findAllByMember(any(Member.class));
         }
     }
 

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/service/FavoriteServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/service/FavoriteServiceTest.java
@@ -9,13 +9,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.fc.shimpyo_be.domain.favorite.dto.FavoriteResponseDto;
+import com.fc.shimpyo_be.domain.favorite.dto.FavoritesResponseDto;
 import com.fc.shimpyo_be.domain.favorite.entity.Favorite;
 import com.fc.shimpyo_be.domain.favorite.repository.FavoriteRepository;
 import com.fc.shimpyo_be.domain.favorite.service.FavoriteService;
 import com.fc.shimpyo_be.domain.member.entity.Authority;
 import com.fc.shimpyo_be.domain.member.entity.Member;
 import com.fc.shimpyo_be.domain.member.service.MemberService;
-import com.fc.shimpyo_be.domain.product.dto.response.ProductResponse;
 import com.fc.shimpyo_be.domain.product.entity.Address;
 import com.fc.shimpyo_be.domain.product.entity.Amenity;
 import com.fc.shimpyo_be.domain.product.entity.Category;
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -191,18 +193,21 @@ public class FavoriteServiceTest {
                 .member(member)
                 .product(product)
                 .build();
+            Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
 
             given(memberService.getMemberById(any(Long.TYPE))).willReturn(member);
-            given(favoriteRepository.findAllByMember(any(Member.class))).willReturn(List.of(favorite));
+            given(favoriteRepository.findAllByMemberId(any(Long.class), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(favorite)));
 
             // when
-            List<ProductResponse> result = favoriteService.getFavorites(1L);
+            FavoritesResponseDto result = favoriteService.getFavorites(1L, pageable);
 
             // then
             assertNotNull(result);
 
             verify(memberService, times(1)).getMemberById(any(Long.TYPE));
-            verify(favoriteRepository, times(1)).findAllByMember(any(Member.class));
+            verify(favoriteRepository, times(1)).findAllByMemberId(any(Long.class),
+                any(Pageable.class));
         }
     }
 


### PR DESCRIPTION
### 💡 Motivation
- 회원이 숙소를 즐겨찾기에 등록, 조회, 취소할 수 있도록 기능을 구현해야 합니다. 

### 📌 Changes
- 즐겨찾기 등록 기능 구현
- 즐겨찾기 등록 기능 구현
- 즐겨찾기 목록 조회 기능 구현
  - 페이지네이션 추가
- 즐겨찾기 취소 기능 구현
- 서비스 테스트 코드 작성
- 레포지토리 테스트 코드 작성
- 컨트롤러 테스트 코드 작성
- REST Docs 테스트 코드 작성
- adoc 파일 작성

### 🫱🏻‍🫲🏻 To Reviewers
- 즐겨찾기 기능 구현 완료했습니다! 재철님은 해당 부분 적용하여 숙소 조회 시 즐겨찾기 여부를 응답할 수 있도록 수정해주시면 감사하겠습니다! 😊👍🏻🩷

this close #113 