### PR TITLE
feat: 별점 등록 기한 제한 검증 로직 구현

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/star/controller/StarRestController.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/star/controller/StarRestController.java
@@ -10,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,7 +23,7 @@ public class StarRestController {
 
     @PostMapping
     public ResponseEntity<ResponseDto<StarResponseDto>> register(@Valid @RequestBody StarRegisterRequestDto request) {
-        log.info("[api][POST] /api/stars");
+        log.debug("[api][POST] /api/stars");
 
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/src/main/java/com/fc/shimpyo_be/domain/star/exception/ExpiredRegisterDateException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/star/exception/ExpiredRegisterDateException.java
@@ -1,0 +1,11 @@
+package com.fc.shimpyo_be.domain.star.exception;
+
+import com.fc.shimpyo_be.global.exception.ApplicationException;
+import com.fc.shimpyo_be.global.exception.ErrorCode;
+
+public class ExpiredRegisterDateException extends ApplicationException {
+
+    public ExpiredRegisterDateException() {
+        super(ErrorCode.EXPIRED_STAR_REGISTER_DATE);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/star/service/StarService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/star/service/StarService.java
@@ -1,8 +1,7 @@
 package com.fc.shimpyo_be.domain.star.service;
 
 import com.fc.shimpyo_be.domain.member.entity.Member;
-import com.fc.shimpyo_be.domain.member.exception.MemberNotFoundException;
-import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
 import com.fc.shimpyo_be.domain.product.entity.Product;
 import com.fc.shimpyo_be.domain.product.exception.ProductNotFoundException;
 import com.fc.shimpyo_be.domain.product.repository.ProductRepository;
@@ -13,6 +12,7 @@ import com.fc.shimpyo_be.domain.star.dto.request.StarRegisterRequestDto;
 import com.fc.shimpyo_be.domain.star.dto.response.StarResponseDto;
 import com.fc.shimpyo_be.domain.star.entity.Star;
 import com.fc.shimpyo_be.domain.star.exception.CannotBeforeCheckOutException;
+import com.fc.shimpyo_be.domain.star.exception.ExpiredRegisterDateException;
 import com.fc.shimpyo_be.domain.star.repository.StarRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +29,7 @@ import java.time.LocalTime;
 public class StarService {
 
     private final StarRepository starRepository;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final ProductRepository productRepository;
     private final ReservationProductRepository reservationProductRepository;
 
@@ -38,8 +38,7 @@ public class StarService {
         log.debug("{} ::: {}", getClass().getSimpleName(), "register");
 
         // 회원 조회
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(MemberNotFoundException::new);
+        Member member = memberService.getMemberById(memberId);
 
         // 예약 숙소 조회
         ReservationProduct reservationProduct = reservationProductRepository.findByIdWithRoom(request.reservationProductId())
@@ -77,11 +76,19 @@ public class StarService {
     }
 
     private void validateRegisterDate(LocalDateTime current, LocalDate endDate, LocalTime checkOut) {
-        LocalDateTime target = LocalDateTime.of(endDate, checkOut);
+        LocalDateTime startDateTime = LocalDateTime.of(endDate, checkOut);
 
-        if (current.isEqual(target) || current.isBefore(target)) {
+        if (current.isEqual(startDateTime) || current.isBefore(startDateTime)) {
             log.error("별점 등록은 체크아웃 이후에 가능합니다.");
             throw new CannotBeforeCheckOutException();
+        }
+
+        LocalDateTime endDateTime =
+            LocalDateTime.of(endDate.plusDays(14), LocalTime.of(23, 59, 59));
+
+        if (current.isAfter(endDateTime)) {
+            log.error("별점 등록은 체크아웃 후 2주 이내에만 가능합니다.");
+            throw new ExpiredRegisterDateException();
         }
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode {
     CART_NOT_DELETE(HttpStatus.FORBIDDEN, "해당 장바구니를 삭제할 권한이 없습니다"),
 
     // 별점
-    REGISTER_BEFORE_CHECKOUT(HttpStatus.BAD_REQUEST, "별점 등록 가능 기간이 아닙니다."),
+    REGISTER_BEFORE_CHECKOUT(HttpStatus.BAD_REQUEST, "별점 등록은 체크아웃 이후에 가능합니다."),
+    EXPIRED_STAR_REGISTER_DATE(HttpStatus.BAD_REQUEST, "별점 등록 가능 기간이 만료되었습니다.(체크아웃 후 2주 이내)"),
 
     // Open API
     HTTP_CLIENT_CONNECTION_ERROR(HttpStatus.UNAUTHORIZED, "외부 API 연결에 실패했습니다."),

--- a/src/test/java/com/fc/shimpyo_be/domain/star/unit/controller/StarRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/star/unit/controller/StarRestControllerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fc.shimpyo_be.config.AbstractContainersSupport;
 import com.fc.shimpyo_be.domain.star.dto.request.StarRegisterRequestDto;
 import com.fc.shimpyo_be.domain.star.dto.response.StarResponseDto;
+import com.fc.shimpyo_be.domain.star.exception.CannotBeforeCheckOutException;
+import com.fc.shimpyo_be.domain.star.exception.ExpiredRegisterDateException;
 import com.fc.shimpyo_be.domain.star.service.StarService;
 import com.fc.shimpyo_be.global.util.SecurityUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -76,5 +79,59 @@ class StarRestControllerTest extends AbstractContainersSupport {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.data.starId").isNumber())
             .andExpect(jsonPath("$.data.score").isNotEmpty());
+    }
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("[api][POST][에러] 별점 등록 API 테스트 - 체크아웃 이전 등록 기간 검증 에러")
+    @Test
+    void register_cannotBeforeCheckOutException_test() throws Exception {
+        // given
+        String requestUrl = "/api/stars";
+        Long productId = 1L;
+        float score = 3.5F;
+
+        StarRegisterRequestDto requestDto
+            = new StarRegisterRequestDto(1L, productId, score);
+
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        given(starService.register(anyLong(), any(StarRegisterRequestDto.class)))
+            .willThrow(new CannotBeforeCheckOutException());
+
+        // when & then
+        mockMvc.perform(
+                post(requestUrl)
+                    .content(objectMapper.writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", is(400)))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("[api][POST][에러] 별점 등록 API 테스트 - 만료된 등록 기간 검증 에러")
+    @Test
+    void register_expiredRegisterDateException_test() throws Exception {
+        // given
+        String requestUrl = "/api/stars";
+        Long productId = 1L;
+        float score = 3.5F;
+
+        StarRegisterRequestDto requestDto
+            = new StarRegisterRequestDto(1L, productId, score);
+
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        given(starService.register(anyLong(), any(StarRegisterRequestDto.class)))
+            .willThrow(new ExpiredRegisterDateException());
+
+        // when & then
+        mockMvc.perform(
+                post(requestUrl)
+                    .content(objectMapper.writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", is(400)))
+            .andExpect(jsonPath("$.data").isEmpty());
     }
 }

--- a/src/test/java/com/fc/shimpyo_be/domain/star/unit/controller/StarRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/star/unit/controller/StarRestControllerTest.java
@@ -53,7 +53,7 @@ class StarRestControllerTest extends AbstractContainersSupport {
     }
 
     @WithMockUser(roles = "USER")
-    @DisplayName("[api][POST] 별점 등록 API 성공 테스트")
+    @DisplayName("[api][POST][정상] 별점 등록 API 테스트")
     @Test
     void register_success_test() throws Exception {
         // given

--- a/src/test/java/com/fc/shimpyo_be/domain/star/unit/service/StarServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/star/unit/service/StarServiceTest.java
@@ -3,7 +3,7 @@ package com.fc.shimpyo_be.domain.star.unit.service;
 import com.fc.shimpyo_be.domain.member.entity.Authority;
 import com.fc.shimpyo_be.domain.member.entity.Member;
 import com.fc.shimpyo_be.domain.member.exception.MemberNotFoundException;
-import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import com.fc.shimpyo_be.domain.member.service.MemberService;
 import com.fc.shimpyo_be.domain.product.entity.Address;
 import com.fc.shimpyo_be.domain.product.entity.Category;
 import com.fc.shimpyo_be.domain.product.entity.Product;
@@ -19,6 +19,7 @@ import com.fc.shimpyo_be.domain.star.dto.request.StarRegisterRequestDto;
 import com.fc.shimpyo_be.domain.star.dto.response.StarResponseDto;
 import com.fc.shimpyo_be.domain.star.entity.Star;
 import com.fc.shimpyo_be.domain.star.exception.CannotBeforeCheckOutException;
+import com.fc.shimpyo_be.domain.star.exception.ExpiredRegisterDateException;
 import com.fc.shimpyo_be.domain.star.repository.StarRepository;
 import com.fc.shimpyo_be.domain.star.service.StarService;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +34,8 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -51,7 +53,7 @@ public class StarServiceTest {
     private StarRepository starRepository;
 
     @Mock
-    private MemberRepository memberRepository;
+    private MemberService memberService;
 
     @Mock
     private ProductRepository productRepository;
@@ -65,7 +67,9 @@ public class StarServiceTest {
 
     private ReservationProduct reservationProduct;
 
-    private ReservationProduct reservationProduct2;
+    private ReservationProduct reservationProductBeforeCheckOut;
+
+    private ReservationProduct reservationProductExpiredToRegister;
 
     @BeforeEach
     void setUp() {
@@ -117,7 +121,7 @@ public class StarServiceTest {
             .endDate(LocalDate.of(2023, 11, 29))
             .build();
 
-        reservationProduct2 = ReservationProduct.builder()
+        reservationProductBeforeCheckOut = ReservationProduct.builder()
             .id(3L)
             .reservation(reservation)
             .room(Room.builder()
@@ -132,7 +136,25 @@ public class StarServiceTest {
                 .checkOut(LocalTime.of(12, 0))
                 .build()
             )
-            .endDate(LocalDate.of(2100, 11, 29))
+            .endDate(LocalDate.now().plusDays(5))
+            .build();
+
+        reservationProductExpiredToRegister = ReservationProduct.builder()
+            .id(4L)
+            .reservation(reservation)
+            .room(Room.builder()
+                .price(RoomPrice.builder()
+                    .offWeekDaysMinFee(50000)
+                    .offWeekendMinFee(60000)
+                    .peakWeekDaysMinFee(100000)
+                    .peakWeekendMinFee(110000)
+                    .build())
+                .description("객실정보")
+                .product(product)
+                .checkOut(LocalTime.of(12, 0))
+                .build()
+            )
+            .endDate(LocalDate.now().minusDays(15))
             .build();
     }
 
@@ -144,8 +166,8 @@ public class StarServiceTest {
         StarRegisterRequestDto request
             = new StarRegisterRequestDto(reservationProduct.getId(), product.getId(), score);
 
-        given(memberRepository.findById(anyLong()))
-            .willReturn(Optional.of(member));
+        given(memberService.getMemberById(anyLong()))
+            .willReturn(member);
         given(productRepository.findById(anyLong()))
             .willReturn(Optional.of(product));
         given(reservationProductRepository.findByIdWithRoom(anyLong()))
@@ -167,7 +189,7 @@ public class StarServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.score()).isEqualTo(score);
 
-        verify(memberRepository, times(1)).findById(anyLong());
+        verify(memberService, times(1)).getMemberById(anyLong());
         verify(productRepository, times(1)).findById(anyLong());
         verify(reservationProductRepository, times(1)).findByIdWithRoom(anyLong());
         verify(starRepository, times(1)).save(any(Star.class));
@@ -182,14 +204,14 @@ public class StarServiceTest {
         StarRegisterRequestDto request
             = new StarRegisterRequestDto(1L, product.getId(), score);
 
-        given(memberRepository.findById(anyLong()))
+        given(memberService.getMemberById(anyLong()))
             .willThrow(MemberNotFoundException.class);
 
         // when & then
         assertThatThrownBy(() -> starService.register(memberId, request))
             .isInstanceOf(MemberNotFoundException.class);
 
-        verify(memberRepository, times(1)).findById(anyLong());
+        verify(memberService, times(1)).getMemberById(anyLong());
         verify(productRepository, times(0)).findById(anyLong());
         verify(starRepository, times(0)).save(any(Star.class));
     }
@@ -204,8 +226,8 @@ public class StarServiceTest {
         StarRegisterRequestDto request
             = new StarRegisterRequestDto(1L, productId, score);
 
-        given(memberRepository.findById(anyLong()))
-            .willReturn(Optional.ofNullable(member));
+        given(memberService.getMemberById(anyLong()))
+            .willReturn(member);
         given(reservationProductRepository.findByIdWithRoom(anyLong()))
             .willReturn(Optional.ofNullable(reservationProduct));
         given(productRepository.findById(anyLong()))
@@ -215,7 +237,7 @@ public class StarServiceTest {
         assertThatThrownBy(() -> starService.register(memberId, request))
             .isInstanceOf(ProductNotFoundException.class);
 
-        verify(memberRepository, times(1)).findById(anyLong());
+        verify(memberService, times(1)).getMemberById(anyLong());
         verify(reservationProductRepository, times(1)).findByIdWithRoom(anyLong());
         verify(productRepository, times(1)).findById(anyLong());
         verify(starRepository, times(0)).save(any(Star.class));
@@ -229,18 +251,44 @@ public class StarServiceTest {
         long productId = 1000L;
         float score = 4F;
         StarRegisterRequestDto request
-            = new StarRegisterRequestDto(1L, productId, score);
+            = new StarRegisterRequestDto(reservationProductBeforeCheckOut.getId(), productId, score);
 
-        given(memberRepository.findById(anyLong()))
-            .willReturn(Optional.ofNullable(member));
+        given(memberService.getMemberById(anyLong()))
+            .willReturn(member);
         given(reservationProductRepository.findByIdWithRoom(anyLong()))
-            .willReturn(Optional.ofNullable(reservationProduct2));
+            .willReturn(Optional.ofNullable(reservationProductBeforeCheckOut));
 
         // when & then
         assertThatThrownBy(() -> starService.register(memberId, request))
             .isInstanceOf(CannotBeforeCheckOutException.class);
 
-        verify(memberRepository, times(1)).findById(anyLong());
+        verify(memberService, times(1)).getMemberById(anyLong());
+        verify(reservationProductRepository, times(1)).findByIdWithRoom(anyLong());
+        verify(productRepository, times(0)).findById(anyLong());
+        verify(starRepository, times(0)).save(any(Star.class));
+    }
+
+    @DisplayName("별점 등록일시가 체크아웃 일시 2주 이후일 경우 등록할 수 없다.")
+    @Test
+    void register_expiredRegisterDateException() {
+        // given
+        long memberId = member.getId();
+        long productId = 1000L;
+        float score = 4F;
+
+        StarRegisterRequestDto request
+            = new StarRegisterRequestDto(reservationProductExpiredToRegister.getId(), productId, score);
+
+        given(memberService.getMemberById(anyLong()))
+            .willReturn(member);
+        given(reservationProductRepository.findByIdWithRoom(anyLong()))
+            .willReturn(Optional.ofNullable(reservationProductExpiredToRegister));
+
+        // when & then
+        assertThatThrownBy(() -> starService.register(memberId, request))
+            .isInstanceOf(ExpiredRegisterDateException.class);
+
+        verify(memberService, times(1)).getMemberById(anyLong());
         verify(reservationProductRepository, times(1)).findByIdWithRoom(anyLong());
         verify(productRepository, times(0)).findById(anyLong());
         verify(starRepository, times(0)).save(any(Star.class));


### PR DESCRIPTION
### 💡 Motivation
- 별점 등록 만료 기한을 2주로 제한합니다.

### 📌 Changes
- 만료기한 지난 별점 등록 케이스에 대한 ErrorCode 추가
- 만료기한 지난 별점 등록에 필요한 Custom Exception 추가 
   - ExpiredRegisterDateException  
- 별점 등록 가능 기간 검증 로직에 만료 기한 검증 로직 추가
- 별점 등록 가능 기간 검증 로직에 대한 서비스 Test 코드 수정 및 추가 작성
- 별점 등록 API의 검증 에러 경우에 대한 Test 코드 추가 작성

### 🫱🏻‍🫲🏻 To Reviewers
- 별점 등록 기간을 2주 이내로 제한 하는 검증 로직을 구현하고 테스트를 작성해 확인했습니다!

This close #100 