### PR TITLE
refactor: 즐겨찾기 응답 시 isLast 필드 제외

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/dto/FavoritesResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/dto/FavoritesResponseDto.java
@@ -11,13 +11,11 @@ import lombok.NoArgsConstructor;
 public class FavoritesResponseDto {
 
     private int pageCount;
-    private Boolean isLast;
     private List<ProductResponse> products;
 
     @Builder
-    public FavoritesResponseDto(int pageCount, Boolean isLast, List<ProductResponse> products) {
+    public FavoritesResponseDto(int pageCount, List<ProductResponse> products) {
         this.pageCount = pageCount;
-        this.isLast = isLast;
         this.products = products;
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/favorite/service/FavoriteService.java
@@ -52,7 +52,6 @@ public class FavoriteService {
         }
         return FavoritesResponseDto.builder()
             .pageCount(favorites.getTotalPages())
-            .isLast(favorites.isLast())
             .products(productResponses)
             .build();
     }

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/docs/FavoriteRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/docs/FavoriteRestControllerDocsTest.java
@@ -71,7 +71,6 @@ public class FavoriteRestControllerDocsTest extends RestDocsSupport {
         // given
         FavoritesResponseDto favoritesResponseDto = FavoritesResponseDto.builder()
             .pageCount(10)
-            .isLast(true)
             .products(List.of(ProductResponse.builder()
                 .productId(1L)
                 .productName("OO 호텔")
@@ -103,8 +102,6 @@ public class FavoriteRestControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
                     fieldWithPath("data.pageCount").type(JsonFieldType.NUMBER)
                         .description("총 페이지 개수"),
-                    fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN)
-                        .description("마지막 페이지 여부"),
                     fieldWithPath("data.products").type(JsonFieldType.ARRAY)
                         .description("숙소 응답 데이터 배열"),
                     fieldWithPath("data.products[].productId").type(

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/controller/FavoriteRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/controller/FavoriteRestControllerTest.java
@@ -102,7 +102,6 @@ public class FavoriteRestControllerTest extends AbstractContainersSupport {
             // given
             FavoritesResponseDto favoritesResponseDto = FavoritesResponseDto.builder()
                 .pageCount(10)
-                .isLast(true)
                 .products(List.of(ProductResponse.builder()
                     .productId(1L)
                     .productName("OO 호텔")
@@ -130,7 +129,6 @@ public class FavoriteRestControllerTest extends AbstractContainersSupport {
                 .andExpect(jsonPath("$.message").isString())
                 .andExpect(jsonPath("$.data").isMap())
                 .andExpect(jsonPath("$.data.pageCount").isNumber())
-                .andExpect(jsonPath("$.data.isLast").isBoolean())
                 .andExpect(jsonPath("$.data.products[0].productId").isNumber())
                 .andExpect(jsonPath("$.data.products[0].productName").isString())
                 .andExpect(jsonPath("$.data.products[0].category").isString())

--- a/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/favorite/unit/repository/FavoriteRepositoryTest.java
@@ -173,7 +173,6 @@ public class FavoriteRepositoryTest {
             // then
             assertThat(result.isEmpty()).isFalse();
             assertThat(result.getTotalPages()).isEqualTo(1);
-            assertThat(result.isLast()).isTrue();
             assertThat(result.get().toList().get(0).getId()).isNotNull();
             assertThat(result.get().toList().get(0).getMember().getId()).isEqualTo(member.getId());
             assertThat(result.get().toList().get(0).getProduct().getId()).isEqualTo(


### PR DESCRIPTION
### 💡 Motivation
- FE 에서 isLast 필드가 불필요하다는 피드백을 주셔서 해당 필드를 삭제하고자 합니다. 

### 📌 Changes
- 즐겨찾기 응답 시 isLast 필드 제외

### 🫱🏻‍🫲🏻 To Reviewers
- isLast만 삭제 했습니다. 승인 부탁드려요!