### PR TITLE
hotfix: 필터를 거치지 않는 url에 authentication이 초기화 안되있을 걸 예상햇지만 초기화 되있는 이슈

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/global/util/SecurityUtil.java
+++ b/src/main/java/com/fc/shimpyo_be/global/util/SecurityUtil.java
@@ -19,9 +19,10 @@ public class SecurityUtil {
     public Long getNullableCurrentMemberId() {
         final Authentication authentication = SecurityContextHolder.getContext()
             .getAuthentication();
-        if (authentication == null || authentication.getName() == null) {
+        if (authentication == null || authentication.getName() == null || authentication.getName().equals("anonymousUser")) {
             return null;
         }
+
         return Long.parseLong(authentication.getName());
     }
 }


### PR DESCRIPTION


### 💡 Motivation
- 필터를 거치지 않는 url이 authentication이 초기화 안 되있을 걸 예상하고, api를 구현했지만, null이 아니어서 이를 수정

### 📌 Changes
- authentication.getName() == 어나니머스 유저이면, 로그인한 유저가 아니기 때문에 수정!!

### 🫱🏻‍🫲🏻 To Reviewers
- 화이팅!