### PR TITLE
 fix: 장바구니 추가 시, 날짜 검증 수정 및 querydsl 사용

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/cart/repository/CartCustomRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/cart/repository/CartCustomRepository.java
@@ -1,0 +1,9 @@
+package com.fc.shimpyo_be.domain.cart.repository;
+
+import com.fc.shimpyo_be.domain.cart.dto.request.CartCreateRequest;
+import java.time.LocalDate;
+
+public interface CartCustomRepository {
+    Long countByRoomCodeAndMemberIdContainsDate (CartCreateRequest cartCreateRequest, Long memberId);
+}
+

--- a/src/main/java/com/fc/shimpyo_be/domain/cart/repository/CartCustomRepositoryImpl.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/cart/repository/CartCustomRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.fc.shimpyo_be.domain.cart.repository;
+
+import static com.fc.shimpyo_be.domain.cart.entity.QCart.cart;
+
+import com.fc.shimpyo_be.domain.cart.dto.request.CartCreateRequest;
+import com.fc.shimpyo_be.global.util.DateTimeUtil;
+import com.querydsl.core.QueryException;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CartCustomRepositoryImpl implements CartCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    CartCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.queryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Long countByRoomCodeAndMemberIdContainsDate(CartCreateRequest cartCreateRequest,
+        Long memberId) {
+
+        LocalDate startDate = DateTimeUtil.toLocalDate(cartCreateRequest.startDate());
+        LocalDate endDate = DateTimeUtil.toLocalDate(cartCreateRequest.endDate());
+
+        return queryFactory
+            .selectFrom(cart)
+            .leftJoin(cart.member)
+            .where(buildSearchConditions(cartCreateRequest.roomCode(), memberId,
+                startDate, endDate)).fetchCount();
+    }
+
+    private BooleanExpression buildSearchConditions(Long roomCode, Long memberId,
+        LocalDate startDate, LocalDate endDate) {
+        List<BooleanExpression> expressions = new ArrayList<>();
+
+        if (roomCode == null || memberId == null || startDate == null || endDate == null) {
+            throw new QueryException("잘못된 쿼리 입니다.");
+        }
+
+        expressions.add(cart.member.id.eq(memberId).and(cart.roomCode.eq(roomCode))
+            .and(cart.startDate.before(endDate).and(cart.endDate.after(startDate))));
+
+        return expressions.stream().reduce(BooleanExpression::and).orElse(null);
+    }
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/cart/repository/CartRepository.java
@@ -2,6 +2,7 @@ package com.fc.shimpyo_be.domain.cart.repository;
 
 
 import com.fc.shimpyo_be.domain.cart.entity.Cart;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CartRepository extends JpaRepository<Cart, Long> {
     Optional<List<Cart>> findByMemberId(Long memberId);
 
-    Long countByRoomCode(Long roomCode);
+
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/cart/service/CartService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/cart/service/CartService.java
@@ -6,6 +6,7 @@ import com.fc.shimpyo_be.domain.cart.dto.response.CartResponse;
 import com.fc.shimpyo_be.domain.cart.entity.Cart;
 import com.fc.shimpyo_be.domain.cart.exception.CartNotDeleteException;
 import com.fc.shimpyo_be.domain.cart.exception.CartNotFoundException;
+import com.fc.shimpyo_be.domain.cart.repository.CartCustomRepositoryImpl;
 import com.fc.shimpyo_be.domain.cart.repository.CartRepository;
 import com.fc.shimpyo_be.domain.cart.util.CartMapper;
 import com.fc.shimpyo_be.domain.member.entity.Member;
@@ -38,14 +39,16 @@ public class CartService {
 
     private final ProductService productService;
 
+    private final CartCustomRepositoryImpl cartCustomRepository;
+
     public List<CartResponse> getCarts() {
         List<Cart> carts = cartRepository.findByMemberId(
             securityUtil.getCurrentMemberId()).orElseThrow();
 
         return carts.stream().map(this::getCartResponse).filter(
-                cartResponse ->
-                    productService.countAvailableForReservationUsingRoomCode(cartResponse.getRoomCode(),
-                        cartResponse.getStartDate(), cartResponse.getEndDate()) > 0).toList();
+            cartResponse ->
+                productService.countAvailableForReservationUsingRoomCode(cartResponse.getRoomCode(),
+                    cartResponse.getStartDate(), cartResponse.getEndDate()) > 0).toList();
     }
 
     @Transactional
@@ -60,7 +63,8 @@ public class CartService {
             cartCreateRequest.endDate());
 
         if (countAvailableForReservation <= 0
-            || cartRepository.countByRoomCode(cartCreateRequest.roomCode()) + 1
+            || cartCustomRepository.countByRoomCodeAndMemberIdContainsDate(
+            cartCreateRequest, member.getId()) + 1
             > countAvailableForReservation) {
             throw new RoomNotReserveException();
         }

--- a/src/test/java/com/fc/shimpyo_be/domain/cart/docs/CartRestIntegrationDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/cart/docs/CartRestIntegrationDocsTest.java
@@ -124,8 +124,10 @@ class CartRestIntegrationDocsTest extends RestDocsSupport {
         CartCreateRequest cartCreateRequest = CartCreateRequest.builder()
             .startDate(DateTimeUtil.toString(
                 tommorrow))
-            .endDate(DateTimeUtil.toString(tommorrow.plusDays(1))).price(100000L)
+            .endDate(DateTimeUtil.toString(tommorrow.plusDays(2))).price(100000L)
             .roomCode(room.getCode()).build();
+
+        cartRepository.save(Cart.builder().roomCode(0L).price(10000L).member(member).startDate(tommorrow.plusDays(2)).endDate(tommorrow.plusDays(3)).build());
         //when
         ResultActions resultActions = mockMvc.perform(
             post("/api/carts").content(objectMapper.writeValueAsString(cartCreateRequest))

--- a/src/test/java/com/fc/shimpyo_be/domain/cart/unit/service/CartRestServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/cart/unit/service/CartRestServiceTest.java
@@ -12,6 +12,7 @@ import com.fc.shimpyo_be.domain.cart.dto.response.CartDeleteResponse;
 import com.fc.shimpyo_be.domain.cart.dto.response.CartResponse;
 import com.fc.shimpyo_be.domain.cart.entity.Cart;
 import com.fc.shimpyo_be.domain.cart.factory.CartFactory;
+import com.fc.shimpyo_be.domain.cart.repository.CartCustomRepositoryImpl;
 import com.fc.shimpyo_be.domain.cart.repository.CartRepository;
 import com.fc.shimpyo_be.domain.cart.service.CartService;
 import com.fc.shimpyo_be.domain.cart.util.CartMapper;
@@ -52,6 +53,9 @@ public class CartRestServiceTest {
     private RoomRepository roomRepository;
     @Mock
     private CartRepository cartRepository;
+
+    @Mock
+    private CartCustomRepositoryImpl cartCustomRepository;
     @Mock
     private SecurityUtil securityUtil;
     @InjectMocks
@@ -100,7 +104,7 @@ public class CartRestServiceTest {
         Cart expectedCart = CartMapper.toCart(cartCreateRequest, member);
         CartResponse expectedCartResponse = CartMapper.toCartResponse(expectedCart, room);
         given(cartRepository.save(any())).willReturn(expectedCart);
-        given(cartRepository.countByRoomCode(any())).willReturn(0L);
+        given(cartCustomRepository.countByRoomCodeAndMemberIdContainsDate(any(), anyLong())).willReturn(0L);
         given(securityUtil.getCurrentMemberId()).willReturn(member.getId());
         given(roomRepository.findByCode(cartCreateRequest.roomCode())).willReturn(List.of(room));
         given(memberRepository.findById(member.getId())).willReturn(Optional.ofNullable(member));


### PR DESCRIPTION
### 💡 Motivation
- 깜빡하고 장바구니 추가 시, 날짜에 따른 보유 수량보다 못 넣게 해야 되는데 검증을 안 해서 구현했습니다. 

### 📌 Changes
- 상품 A 보유수량 >= 장바구니에 있는 상품 A 개수를 확인하는 API 구현
- 장바구니에 있는 상품 A개수를 countSelect하는 querydsl repository 구현 

### 🫱🏻‍🫲🏻 To Reviewers
- 어리고 싶다.