### PR TITLE
refactor, feat: 예약 선점/예약 저장 때 선점한 레디스키 만료기한 다르게 설정하도록 수정 & 예약 저장시 장바구니 삭제 로직 추가

### DIFF
--- a/src/main/java/com/fc/shimpyo_be/domain/cart/service/CartService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/cart/service/CartService.java
@@ -81,6 +81,18 @@ public class CartService {
         return CartMapper.toCartDeleteResponse(cart);
     }
 
+    @Transactional
+    public CartDeleteResponse deleteCart(final Long memberId, final Long cartId) {
+        Cart cart = cartRepository.findById(cartId).orElseThrow(CartNotFoundException::new);
+
+        if (!cart.getMember().getId().equals(memberId)) {
+            throw new CartNotDeleteException();
+        }
+        cartRepository.deleteById(cart.getId());
+
+        return CartMapper.toCartDeleteResponse(cart);
+    }
+
     private CartResponse getCartResponse(final Cart cart) {
         List<Room> rooms = Optional.of(roomRepository.findByCode(cart.getRoomCode()))
             .orElseThrow();

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/ValidateReservationResultDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/ValidateReservationResultDto.java
@@ -1,0 +1,14 @@
+package com.fc.shimpyo_be.domain.reservation.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record ValidateReservationResultDto(
+    boolean isAvailable,
+    List<Long> unavailableIds,
+    Map<Long, List<String>> confirmMap
+) {
+}

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/PreoccupyRoomItemRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/request/PreoccupyRoomItemRequestDto.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 @Builder
 public record PreoccupyRoomItemRequestDto(
     @NotNull
+    Long cartId,
+    @NotNull
     Long roomCode,
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 날짜 형식이 아닙니다.(yyyy-MM-dd 형식으로 입력하세요.)")
     String startDate,

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/ValidatePreoccupyRoomResponseDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/dto/response/ValidatePreoccupyRoomResponseDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record ValidatePreoccupyRoomResponseDto(
+    Long cartId,
     Long roomCode,
     String startDate,
     String endDate,

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/ReserveNotAvailableException.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/exception/ReserveNotAvailableException.java
@@ -11,13 +11,13 @@ public class ReserveNotAvailableException extends RuntimeException {
     private ValidateReservationResultResponseDto data;
 
     public ReserveNotAvailableException() {
-        super(ErrorCode.UNAVAILABLE_ROOMS.getSimpleMessage());
-        this.errorCode = ErrorCode.UNAVAILABLE_ROOMS;
+        super(ErrorCode.RESERVATION_VALIDATION_FAIL.getSimpleMessage());
+        this.errorCode = ErrorCode.RESERVATION_VALIDATION_FAIL;
     }
 
     public ReserveNotAvailableException(ValidateReservationResultResponseDto data) {
-        super(ErrorCode.UNAVAILABLE_ROOMS.getSimpleMessage());
-        this.errorCode = ErrorCode.UNAVAILABLE_ROOMS;
+        super(ErrorCode.RESERVATION_VALIDATION_FAIL.getSimpleMessage());
+        this.errorCode = ErrorCode.RESERVATION_VALIDATION_FAIL;
         this.data = data;
     }
 }

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/facade/ReservationLockFacade.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/facade/ReservationLockFacade.java
@@ -1,5 +1,6 @@
 package com.fc.shimpyo_be.domain.reservation.facade;
 
+import com.fc.shimpyo_be.domain.reservation.dto.ValidateReservationResultDto;
 import com.fc.shimpyo_be.domain.reservation.dto.request.SaveReservationRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.SaveReservationResponseDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.ValidateReservationResultResponseDto;
@@ -34,7 +35,7 @@ public class ReservationLockFacade {
                 throw new RedissonLockFailException();
             }
 
-            ValidateReservationResultResponseDto resultDto = reservationService.validate(memberId, request.reservationProducts());
+            ValidateReservationResultDto resultDto = reservationService.validate(memberId, request.reservationProducts());
 
             if(!resultDto.isAvailable()) {
                 log.debug("[{}][validate rooms result] isAvailable = {}, unavailableIds = {}", currentWorker, false, resultDto.unavailableIds());
@@ -46,9 +47,10 @@ public class ReservationLockFacade {
                         .build()
                 );
             }
+
             log.debug("[{}][validate rooms result] isAvailable = {}, unavailableIds = {}", currentWorker, true, resultDto.unavailableIds());
 
-            return reservationService.saveReservation(memberId, request);
+            return reservationService.saveReservation(memberId, request, resultDto.confirmMap());
 
         } catch (InterruptedException exception) {
             log.error("exception : {}, message : {}", exception.getClass().getSimpleName(), exception.getMessage());

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
@@ -41,6 +41,7 @@ public class PreoccupyRoomsService {
 
             LocalDate startDate = DateTimeUtil.toLocalDate(room.startDate());
             LocalDate endDate = DateTimeUtil.toLocalDate(room.endDate());
+            Long cartId = room.cartId();
             Long roomCode = room.roomCode();
 
             List<Long> roomIds = roomService.getRoomIdsByCode(roomCode);
@@ -78,6 +79,7 @@ public class PreoccupyRoomsService {
 
                     roomResults.add(
                         ValidatePreoccupyRoomResponseDto.builder()
+                            .cartId(cartId)
                             .roomCode(roomCode)
                             .startDate(DateTimeUtil.toString(startDate))
                             .endDate(DateTimeUtil.toString(endDate))
@@ -96,6 +98,7 @@ public class PreoccupyRoomsService {
 
                 roomResults.add(
                     ValidatePreoccupyRoomResponseDto.builder()
+                        .cartId(cartId)
                         .roomCode(roomCode)
                         .startDate(DateTimeUtil.toString(startDate))
                         .endDate(DateTimeUtil.toString(endDate))

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/service/PreoccupyRoomsService.java
@@ -1,8 +1,8 @@
 package com.fc.shimpyo_be.domain.reservation.service;
 
 import com.fc.shimpyo_be.domain.reservation.dto.CheckAvailableRoomsResultDto;
-import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomItemRequestDto;
+import com.fc.shimpyo_be.domain.reservation.dto.request.PreoccupyRoomsRequestDto;
 import com.fc.shimpyo_be.domain.reservation.dto.response.ValidatePreoccupyRoomResponseDto;
 import com.fc.shimpyo_be.domain.room.service.RoomService;
 import com.fc.shimpyo_be.global.util.DateTimeUtil;
@@ -13,6 +13,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
 
@@ -23,7 +24,7 @@ public class PreoccupyRoomsService {
 
     private final RoomService roomService;
     private final RedisTemplate<String, Object> redisTemplate;
-    private static final String REDIS_KEY_FORMAT = "roomId:%d:%s";
+    private static final String PREOCCUPY_REDIS_KEY_FORMAT = "roomId:%d:%s";
     private static final String CHECK_DUPLICATE_FORMAT = "%d:%s:%s";
 
     public CheckAvailableRoomsResultDto checkAvailable(Long memberId, PreoccupyRoomsRequestDto request) {
@@ -55,7 +56,7 @@ public class PreoccupyRoomsService {
                 LocalDate targetDate = startDate;
                 while(targetDate.isBefore(endDate)) {
 
-                    String key = String.format(REDIS_KEY_FORMAT, roomId, targetDate);
+                    String key = String.format(PREOCCUPY_REDIS_KEY_FORMAT, roomId, targetDate);
                     Object value = opsForValue.get(key);
 
                     log.info("roomId: {}, targetDate: {}, value: {}", roomId, targetDate, value);
@@ -120,17 +121,17 @@ public class PreoccupyRoomsService {
             Map<String, String> map = preoccupyMap.get(roomResult.roomId());
             opsForValue.multiSet(map);
 
-            Date expireDate = convertLocalDateToDate(DateTimeUtil.toLocalDate(roomResult.endDate()));
+            Date expireDate = convertLocalDateTimeToDate(LocalDateTime.now().plusMinutes(35));
             for (String key : map.keySet()) {
                 redisTemplate.expireAt(key, expireDate);
             }
         }
     }
 
-    private Date convertLocalDateToDate(LocalDate localDate) {
+    private Date convertLocalDateTimeToDate(LocalDateTime dateTime) {
         return Date.from(
-            localDate
-                .atStartOfDay(ZoneId.systemDefault())
+            dateTime
+                .atZone(ZoneId.systemDefault())
                 .toInstant()
         );
     }

--- a/src/main/java/com/fc/shimpyo_be/domain/reservation/util/ReservationMapper.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservation/util/ReservationMapper.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class ReservationMapper {
 
-    public static ReservationInfoResponseDto from(ReservationProduct reservationProduct) {
+    public static ReservationInfoResponseDto toReservationInfoResponseDto(ReservationProduct reservationProduct) {
         Reservation reservation = reservationProduct.getReservation();
         Room room = reservationProduct.getRoom();
         Product product = room.getProduct();
@@ -39,7 +39,7 @@ public class ReservationMapper {
             .build();
     }
 
-    public static SaveReservationResponseDto from(Reservation reservation) {
+    public static SaveReservationResponseDto toSaveReservationResponseDto(Reservation reservation) {
         List<ReservationProductResponseDto> reservationProductDtos = new ArrayList<>();
         for (ReservationProduct reservationProduct : reservation.getReservationProducts()) {
 

--- a/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/dto/request/ReservationProductRequestDto.java
+++ b/src/main/java/com/fc/shimpyo_be/domain/reservationproduct/dto/request/ReservationProductRequestDto.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 @Builder
 public record ReservationProductRequestDto(
     @NotNull
+    Long cartId,
+    @NotNull
     Long roomId,
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "올바른 날짜 형식이 아닙니다.(yyyy-MM-dd 형식으로 입력하세요.)")
     String startDate,

--- a/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/fc/shimpyo_be/global/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     // 예약
     UNAVAILABLE_ROOMS(HttpStatus.BAD_REQUEST, "예약 불가능한 방이 존재합니다."),
     LOCK_FAIL(HttpStatus.BAD_REQUEST, "요청 완료에 실패했습니다. 재시도가 필요합니다."),
-    INVALID_RESERVATION_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 예약 요청 데이터입니다."),
+    RESERVATION_VALIDATION_FAIL(HttpStatus.BAD_REQUEST, "예약 선점 기한이 만료되었거나, 잘못된 예약 요청으로 예약이 불가합니다."),
 
     // 예약 숙소
     RESERVATION_PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "예약 숙소 정보를 찾을 수 없습니다."),

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/docs/ReservationRestControllerDocsTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/docs/ReservationRestControllerDocsTest.java
@@ -84,6 +84,7 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
             .reservationProducts(
                 List.of(
                     ReservationProductRequestDto.builder()
+                        .cartId(2L)
                         .roomId(1L)
                         .startDate("2023-11-20")
                         .endDate("2023-11-23")
@@ -92,6 +93,7 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                         .price(300000)
                         .build(),
                     ReservationProductRequestDto.builder()
+                        .cartId(7L)
                         .roomId(2L)
                         .startDate("2023-12-10")
                         .endDate("2023-12-12")
@@ -159,6 +161,9 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                         fieldWithPath("reservationProducts").type(JsonFieldType.ARRAY).description("예약할 객실 숙소 리스트")
                             .attributes(key("constraints").value(
                                 saveReservationDescriptions.descriptionsForProperty("reservationProducts"))),
+                        fieldWithPath("reservationProducts[].cartId").type(JsonFieldType.NUMBER).description("장바구니 식별자")
+                            .attributes(key("constraints").value(
+                                reservationProductDescriptions.descriptionsForProperty("cartId"))),
                         fieldWithPath("reservationProducts[].roomId").type(JsonFieldType.NUMBER).description("예약할 객실 식별자")
                             .attributes(key("constraints").value(
                                 reservationProductDescriptions.descriptionsForProperty("roomId"))),
@@ -319,10 +324,10 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                 .rooms(
                     List.of(
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomCode(1001L).startDate("2023-12-23").endDate("2023-12-25")
+                            .cartId(1L).roomCode(1001L).startDate("2023-12-23").endDate("2023-12-25")
                             .build(),
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomCode(1002L).startDate("2023-11-11").endDate("2023-11-14")
+                            .cartId(2L).roomCode(1002L).startDate("2023-11-11").endDate("2023-11-14")
                             .build()
                     )
                 )
@@ -334,12 +339,14 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                 .roomResults(
                     List.of(
                         ValidatePreoccupyRoomResponseDto.builder()
+                            .cartId(1L)
                             .roomCode(1001L)
                             .startDate("2023-12-23")
                             .endDate("2023-12-25")
                             .roomId(1L)
                             .build(),
                         ValidatePreoccupyRoomResponseDto.builder()
+                            .cartId(2L)
                             .roomCode(1002L)
                             .startDate("2023-11-11")
                             .endDate("2023-11-14")
@@ -364,6 +371,9 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                         fieldWithPath("rooms").type(JsonFieldType.ARRAY).description("예약할 객실 리스트")
                             .attributes(key("constraints").value(
                                 preoccupyRoomsDescriptions.descriptionsForProperty("rooms"))),
+                        fieldWithPath("rooms[].cartId").type(JsonFieldType.NUMBER).description("장바구니 식별자")
+                            .attributes(key("constraints").value(
+                                preoccupyRoomItemDescriptions.descriptionsForProperty("cartId"))),
                         fieldWithPath("rooms[].roomCode").type(JsonFieldType.NUMBER).description("예약할 객실 코드")
                             .attributes(key("constraints").value(
                                 preoccupyRoomItemDescriptions.descriptionsForProperty("roomCode"))),
@@ -378,6 +388,7 @@ public class ReservationRestControllerDocsTest extends RestDocsSupport {
                         fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
                         fieldWithPath("data.isAvailable").type(JsonFieldType.BOOLEAN).description("예약 선점 가능 여부"),
                         fieldWithPath("data.roomResults").type(JsonFieldType.ARRAY).description("객실별 예약 선점 가능 검증 결과 리스트"),
+                        fieldWithPath("data.roomResults[].cartId").type(JsonFieldType.NUMBER).description("장바구니 식별자"),
                         fieldWithPath("data.roomResults[].roomCode").type(JsonFieldType.NUMBER).description("객실 코드"),
                         fieldWithPath("data.roomResults[].startDate").type(JsonFieldType.STRING).description("숙박 시작일"),
                         fieldWithPath("data.roomResults[].endDate").type(JsonFieldType.STRING).description("숙박 마지막일"),

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/controller/ReservationRestControllerTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/controller/ReservationRestControllerTest.java
@@ -83,6 +83,7 @@ public class ReservationRestControllerTest extends AbstractContainersSupport {
             .reservationProducts(
                 List.of(
                     ReservationProductRequestDto.builder()
+                        .cartId(1L)
                         .roomId(1L)
                         .startDate("2023-11-20")
                         .endDate("2023-11-23")
@@ -91,6 +92,7 @@ public class ReservationRestControllerTest extends AbstractContainersSupport {
                         .price(300000)
                         .build(),
                     ReservationProductRequestDto.builder()
+                        .cartId(2L)
                         .roomId(3L)
                         .startDate("2023-12-10")
                         .endDate("2023-12-12")
@@ -218,11 +220,13 @@ public class ReservationRestControllerTest extends AbstractContainersSupport {
                 .rooms(
                     List.of(
                         PreoccupyRoomItemRequestDto.builder()
+                            .cartId(1L)
                             .roomCode(1001L)
                             .startDate("2023-12-23")
                             .endDate("2023-12-25")
                             .build(),
                         PreoccupyRoomItemRequestDto.builder()
+                            .cartId(2L)
                             .roomCode(1003L)
                             .startDate("2023-11-11")
                             .endDate("2023-11-14")
@@ -237,12 +241,14 @@ public class ReservationRestControllerTest extends AbstractContainersSupport {
                 .roomResults(
                     List.of(
                         ValidatePreoccupyRoomResponseDto.builder()
+                            .cartId(1L)
                             .roomCode(1001L)
                             .startDate("2023-12-23")
                             .endDate("2023-12-25")
                             .roomId(1L)
                             .build(),
                         ValidatePreoccupyRoomResponseDto.builder()
+                            .cartId(2L)
                             .roomCode(1003L)
                             .startDate("2023-11-11")
                             .endDate("2023-11-14")
@@ -279,16 +285,16 @@ public class ReservationRestControllerTest extends AbstractContainersSupport {
                 .rooms(
                     List.of(
                         PreoccupyRoomItemRequestDto.builder()
-                            .startDate("2023-12-23").endDate("2023-12-25")
+                            .cartId(1L).roomCode(1001L).startDate("2023-12-23").endDate("2023-12-25")
                             .build(),
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomCode(1002L).startDate("2023-11-11").endDate("2023-11-14")
+                            .cartId(2L).roomCode(1002L).startDate("2023-11-11").endDate("2023-11-14")
                             .build(),
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomCode(1003L).startDate("2023-11-11").endDate("2023-11-14")
+                            .cartId(3L).roomCode(1003L).startDate("2023-11-11").endDate("2023-11-14")
                             .build(),
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomCode(1004L).startDate("2023-11-16").endDate("2023-11-18")
+                            .cartId(4L).roomCode(1004L).startDate("2023-11-16").endDate("2023-11-18")
                             .build()
                     )
                 )
@@ -319,13 +325,13 @@ public class ReservationRestControllerTest extends AbstractContainersSupport {
                 .rooms(
                     List.of(
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomCode(1001L).startDate("202-12-23").endDate("2023-12-25")
+                            .cartId(1L).roomCode(1001L).startDate("202-12-23").endDate("2023-12-25")
                             .build(),
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomCode(1002L).startDate("2023-11-11").endDate("2023-11-14")
+                            .cartId(2L).roomCode(1002L).startDate("2023-11-11").endDate("2023-11-14")
                             .build(),
                         PreoccupyRoomItemRequestDto.builder()
-                            .roomCode(1003L).startDate("2023-11-11").endDate("2023-11-14")
+                            .cartId(3L).roomCode(1003L).startDate("2023-11-11").endDate("2023-11-14")
                             .build()
                     )
                 )

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/facade/ReservationLockFacadeTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/facade/ReservationLockFacadeTest.java
@@ -1,27 +1,39 @@
 package com.fc.shimpyo_be.domain.reservation.unit.facade;
 
 import com.fc.shimpyo_be.config.AbstractContainersSupport;
+import com.fc.shimpyo_be.config.DatabaseCleanUp;
+import com.fc.shimpyo_be.config.TestDBCleanerConfig;
+import com.fc.shimpyo_be.domain.member.entity.Authority;
+import com.fc.shimpyo_be.domain.member.entity.Member;
+import com.fc.shimpyo_be.domain.member.repository.MemberRepository;
+import com.fc.shimpyo_be.domain.product.entity.*;
+import com.fc.shimpyo_be.domain.product.repository.ProductRepository;
 import com.fc.shimpyo_be.domain.reservation.dto.request.SaveReservationRequestDto;
 import com.fc.shimpyo_be.domain.reservation.entity.PayMethod;
 import com.fc.shimpyo_be.domain.reservation.facade.ReservationLockFacade;
 import com.fc.shimpyo_be.domain.reservationproduct.dto.request.ReservationProductRequestDto;
+import com.fc.shimpyo_be.domain.room.entity.Room;
+import com.fc.shimpyo_be.domain.room.entity.RoomOption;
+import com.fc.shimpyo_be.domain.room.entity.RoomPrice;
+import com.fc.shimpyo_be.domain.room.repository.RoomRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.util.StopWatch;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 @Slf4j
+@Import(TestDBCleanerConfig.class)
 @SpringBootTest
 class ReservationLockFacadeTest extends AbstractContainersSupport {
 
@@ -30,6 +42,22 @@ class ReservationLockFacadeTest extends AbstractContainersSupport {
 
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    private final String[] tableNameArray = {
+        "member", "product", "room", "product_option", "address", "room_option", "amenity"
+    };
 
     private static final ThreadLocal<StopWatch> threadLocalStopWatch = ThreadLocal.withInitial(StopWatch::new);
 
@@ -40,6 +68,115 @@ class ReservationLockFacadeTest extends AbstractContainersSupport {
         long memberId3 = 3L;
         long memberId4 = 4L;
         long memberId5 = 5L;
+
+        databaseCleanUp.cleanUp(tableNameArray);
+
+        for (int i = 1; i <= 5; i++) {
+            String name = "member" + i;
+            memberRepository.save(
+                Member.builder()
+                    .email(name + "@email.com")
+                    .name(name)
+                    .password("password")
+                    .photoUrl("member photo url")
+                    .authority(Authority.ROLE_USER)
+                    .build()
+            );
+        }
+
+        List<Product> products = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            String productName = "호텔" + i;
+            float starAvg = ThreadLocalRandom.current().nextFloat(0, 5);
+            String infoCenter = String.format("02-1234-%d%d%d%d", i, i, i, i);
+            products.add(
+                productRepository.save(
+                    Product.builder()
+                        .name(productName)
+                        .thumbnail(productName + " 썸네일 url")
+                        .description(productName + " 설명")
+                        .starAvg(starAvg)
+                        .category(Category.TOURIST_HOTEL)
+                        .address(
+                            Address.builder()
+                                .address(productName + " 주소")
+                                .detailAddress(productName + " 상세 주소")
+                                .mapX(1.0)
+                                .mapY(1.5)
+                                .build()
+                        )
+                        .productOption(
+                            ProductOption.builder()
+                                .cooking(true)
+                                .foodPlace("음료 가능")
+                                .parking(true)
+                                .pickup(false)
+                                .infoCenter(infoCenter)
+                                .build()
+                        )
+                        .amenity(
+                            Amenity.builder()
+                                .barbecue(false)
+                                .beauty(true)
+                                .beverage(true)
+                                .fitness(true)
+                                .bicycle(false)
+                                .campfire(false)
+                                .karaoke(true)
+                                .publicBath(true)
+                                .publicPc(true)
+                                .seminar(false)
+                                .sports(false)
+                                .build()
+                        )
+                        .build()
+                )
+            );
+        }
+
+        List<Room> rooms = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            String roomName = "객실" + i;
+            rooms.add(
+                roomRepository.save(
+                    Room.builder()
+                        .product(products.get((i - 1) % 3))
+                        .name(roomName)
+                        .description(roomName + " 설명")
+                        .standard(2)
+                        .capacity(4)
+                        .checkIn(LocalTime.of(14, 0))
+                        .checkOut(LocalTime.of(12, 0))
+                        .price(
+                            RoomPrice.builder()
+                                .offWeekDaysMinFee(75000)
+                                .offWeekendMinFee(85000)
+                                .peakWeekDaysMinFee(100000)
+                                .peakWeekendMinFee(120000)
+                                .build()
+                        )
+                        .roomOption(
+                            RoomOption.builder()
+                                .cooking(true)
+                                .airCondition(true)
+                                .bath(true)
+                                .bathFacility(true)
+                                .pc(false)
+                                .diningTable(true)
+                                .hairDryer(true)
+                                .homeTheater(false)
+                                .internet(true)
+                                .cable(false)
+                                .refrigerator(true)
+                                .sofa(true)
+                                .toiletries(true)
+                                .tv(true)
+                                .build()
+                        )
+                        .build()
+                )
+            );
+        }
 
         saveRedisData(memberId1, 2L, LocalDate.of(2023, 11, 20), LocalDate.of(2023, 11, 23));
         saveRedisData(memberId1, 3L, LocalDate.of(2023, 11, 24), LocalDate.of(2023, 11, 26));
@@ -196,7 +333,7 @@ class ReservationLockFacadeTest extends AbstractContainersSupport {
 
         while (start.isBefore(end)) {
             String key = String.format(keyFormat, roomId, start);
-            valueOperations.set(key, String.valueOf(memberId), 50, TimeUnit.SECONDS);
+            valueOperations.set(key, String.valueOf(memberId), 60, TimeUnit.SECONDS);
             start = start.plusDays(1);
         }
     }

--- a/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/facade/ReservationLockFacadeTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/reservation/unit/facade/ReservationLockFacadeTest.java
@@ -205,46 +205,46 @@ class ReservationLockFacadeTest extends AbstractContainersSupport {
 
         SaveReservationRequestDto request1 = new SaveReservationRequestDto(
             List.of(
-                new ReservationProductRequestDto(2L, "2023-11-20", "2023-11-23",
+                new ReservationProductRequestDto(1L, 2L, "2023-11-20", "2023-11-23",
                     "visitor1", "010-1111-1111", 100000),
-                new ReservationProductRequestDto(3L, "2023-11-24", "2023-11-26",
+                new ReservationProductRequestDto(2L, 3L, "2023-11-24", "2023-11-26",
                     "visitor2", "010-2222-2222", 150000)
             ), PayMethod.KAKAO_PAY, 250000
         );
 
         SaveReservationRequestDto request2 = new SaveReservationRequestDto(
-            List.of(new ReservationProductRequestDto(4L, "2023-10-10", "2023-10-14",
+            List.of(new ReservationProductRequestDto(3L, 4L, "2023-10-10", "2023-10-14",
                 "visitor3", "010-3333-3333", 125000)),
             PayMethod.CREDIT_CARD, 125000
         );
 
         SaveReservationRequestDto request3 = new SaveReservationRequestDto(
             List.of(
-                new ReservationProductRequestDto(2L, "2023-11-10", "2023-11-14",
+                new ReservationProductRequestDto(4L, 2L, "2023-11-10", "2023-11-14",
                     "visitor", "010-1111-1111", 90000),
-                new ReservationProductRequestDto(5L, "2023-10-17", "2023-10-20",
+                new ReservationProductRequestDto(5L, 5L, "2023-10-17", "2023-10-20",
                     "visitor", "010-1111-1111", 110000),
-                new ReservationProductRequestDto(3L, "2023-10-10", "2023-10-14",
+                new ReservationProductRequestDto(6L, 3L, "2023-10-10", "2023-10-14",
                     "visitor", "010-1111-1111", 100000)
             ), PayMethod.NAVER_PAY, 300000
         );
 
         SaveReservationRequestDto request4 = new SaveReservationRequestDto(
             List.of(
-                new ReservationProductRequestDto(4L, "2023-10-05", "2023-10-07",
+                new ReservationProductRequestDto(7L, 4L, "2023-10-05", "2023-10-07",
                     "visitor", "010-1111-1111", 125000),
-                new ReservationProductRequestDto(5L, "2023-10-10", "2023-10-14",
+                new ReservationProductRequestDto(8L, 5L, "2023-10-10", "2023-10-14",
                     "visitor", "010-1111-1111", 125000)
                 ), PayMethod.KAKAO_PAY, 250000
         );
 
         SaveReservationRequestDto request5 = new SaveReservationRequestDto(
             List.of(
-                new ReservationProductRequestDto(1L, "2023-10-10", "2023-10-14",
+                new ReservationProductRequestDto(9L, 1L, "2023-10-10", "2023-10-14",
                     "visitor4", "010-4444-4444", 150000),
-                new ReservationProductRequestDto(2L, "2023-12-11", "2023-12-15",
+                new ReservationProductRequestDto(10L, 2L, "2023-12-11", "2023-12-15",
                     "visitor4", "010-4444-4444", 150000),
-                new ReservationProductRequestDto(4L, "2023-11-11", "2023-11-14",
+                new ReservationProductRequestDto(11L, 4L, "2023-11-11", "2023-11-14",
                     "visitor4", "010-4444-4444", 100000)
                 ), PayMethod.PAYPAL, 400000
         );

--- a/src/test/java/com/fc/shimpyo_be/domain/star/unit/service/StarServiceTest.java
+++ b/src/test/java/com/fc/shimpyo_be/domain/star/unit/service/StarServiceTest.java
@@ -118,7 +118,7 @@ public class StarServiceTest {
                 .checkOut(LocalTime.of(12, 0))
                 .build()
             )
-            .endDate(LocalDate.of(2023, 11, 29))
+            .endDate(LocalDate.now().minusDays(7))
             .build();
 
         reservationProductBeforeCheckOut = ReservationProduct.builder()


### PR DESCRIPTION
### 💡 Motivation
- 예약 선점시 체크아웃 시간을 만료기한으로 할 경우, 결제까지 이어지지 않은 경우에 대한 보상 로직이 필요합니다.
- 예약 선점만 한 경우 선점 만료기한을 35분으로 주고, 결제시 검증 후에 만료기한을 기존처럼 체크아웃 시간으로 재설정해 확정합니다.
- 예약이 정상적으로 완료된 경우 해당 장바구니 아이템이 삭제되는 로직을 예약 저장 서비스 로직에서 진행하도록 추가 구현합니다.

### 📌 Changes
- 예약 선점 preoccupy()에서 레디스 키에 대한 만료기한 35분으로 설정
- 예약 결제 전 검증 로직 예외 처리 Custom Exception 및 ErrorCode 추가
- 예약 결제 전 검증 로직 예외 처리 로직 리팩토링
- 예약 결제 서비스 로직에서 예약 선점시 저장해 둔 레디스 키의 만료기한 '숙박 마지막일'로 재설정 -> 예약 확정
- 예약 선점와 결제 기능에 대한 Request/Response DTO 에 장바구니 식별자 'cartId' 추가 
- 예약 선점 전 검증/선점 로직의 Response에 요청시 받은 'cartId' 추가
- 예약 결제시 장바구니 아이템 삭제 로직 추가
- 변경 사항에 대해 기존 Unit Test 코드 수정 및 정상 동작 확인 
- 예약 관련 API Request/Response 변경에 따른 Docs Test 수정 및 정상 동작 확인

### 🫱🏻‍🫲🏻 To Reviewers
- 어제 테스트에서 결제가 완료되지 않은 경우, 선점이 취소되어야 하는 문제 해결을 위해 예약 선점/예약 결제 로직을 수정했습니다!
- 어제 의논한 결과 예약 결제 완료시 그에 해당하는 장바구니를 삭제해야한다는 추가 기능 요구사항을 구현 완료했습니다!

This close #127 